### PR TITLE
Feat/json multitest

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,19 +57,30 @@ Tests consist of two parts:
 *test config file format:*
 ```json
 {
-    "cmd": "starknet_blockHashAndNumber",
-    "arg": [],
-    "block_range": {
-        "start_inclusive": 0,
-        "stop_inclusive": 1
-    }
+    "tests": [
+        {
+            "cmd": "rp_method1",
+            "arg": [ "..." ],
+        },
+        {
+            "cmd": "rpc_method2",
+            "arg": [ ],
+            "block_range": {
+                "start_inclusive": 0,
+                "stop_inclusive": 1000
+            }
+        }
+    ]
 }
 ```
 
 config file fields:
+- `tests`: all the rpc calls to test against.
 - `cmd`: the rpc command to query the node with.
 - `arg`: the arguments used during the rpc call.
 - *`block_range`* **(optional)**: the range of starknet blocks to run the unit test against.
+
+Each test specified in `tests` will result in an RPC call to the specified Alchemy and Deoxys nodes, comparing each result. Tests marked with `block_range` will be run against each block in the specified range. Please note that this significantly lengthens test time and should only be used for non-trivial calls whose functioning might have been different in earlier versions of the blockchain.
 
 ### In `lib.rs`
 
@@ -95,3 +106,13 @@ mod tests {
     fn block_data_test() {}
 }
 ```
+
+## Structure Format
+
+> ⚠️ Structure members must have the **exact same name** as the json fields expected as an RPC call result.
+
+- For fields which are themselves a JSON object, use another struct to represent this sub-object.
+- For fields that might be optional, use `Option`.
+
+Try and test as many edge cases as possible. Ths mostly includes optional parameters. You can find a list
+of Starknet RPC call and their arguments / return data [here](https://playground.open-rpc.org/?uiSchema%5BappBar%5D%5Bui:splitView%5D=false&schemaUrl=https://raw.githubusercontent.com/starkware-libs/starknet-specs/master/api/starknet_api_openrpc.json&uiSchema%5BappBar%5D%5Bui:input%5D=false&uiSchema%5BappBar%5D%5Bui:darkMode%5D=true&uiSchema%5BappBar%5D%5Bui:examplesDropdown%5D=false)

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@
 
 # ⚙️ Ditto: Library to test and benchmark Kasar infra
 
-_A simple Rust RPC test utility for the [Deoxis](https://github.com/KasarLabs/deoxys) Starknet node._
+_A simple Rust RPC test utility for the [Deoxys](https://github.com/KasarLabs/deoxys) Starknet node._
 
 ## Getting started
 

--- a/rpc_test/src/test_data.rs
+++ b/rpc_test/src/test_data.rs
@@ -4,6 +4,11 @@ use std::{fs::File, io::Read};
 
 #[derive(Deserialize, Debug, PartialEq)]
 pub struct TestData {
+    pub tests: Vec<Unit>
+}
+
+#[derive(Deserialize, Debug, PartialEq)]
+pub struct Unit {
     pub cmd: String,
     pub arg: Vec<String>,
     pub block_range: Option<BlockRange>,

--- a/rpc_test_attribute/src/lib.rs
+++ b/rpc_test_attribute/src/lib.rs
@@ -46,21 +46,23 @@ pub fn rpc_test(args: TokenStream, input: TokenStream) -> TokenStream {
                 .with_context(|| format!("Could not retrieve test data from {path}"))
                 .unwrap();
 
-            let range = match test_data.block_range {
-                Some(range) => range.start_inclusive..=range.stop_inclusive,
-                None => 0..=1,
-            };
+            for test in test_data.tests {
+                let range = match test.block_range {
+                    Some(range) => range.start_inclusive..=range.stop_inclusive,
+                    None => 0..=1,
+                };
 
-            for _ in range {
-                let response_alchemy: #arg_struct = #arg_struct::call(&alchemy, &test_data.cmd, test_data.arg.clone()).await
-                    .with_context(|| format!("Error waiting for rpc call response from Alchemy in test {path}"))
-                    .unwrap();
+                for _ in range {
+                    let response_alchemy: #arg_struct = #arg_struct::call(&alchemy, &test.cmd, test.arg.clone()).await
+                        .with_context(|| format!("Error waiting for rpc call response from Alchemy in test {path}"))
+                        .unwrap();
 
-                let response_deoxys: #arg_struct = #arg_struct::call(&deoxys, &test_data.cmd, test_data.arg.clone()).await
-                    .with_context(|| format!("Error waiting for rpc call response from Deoxys in test {path}"))
-                    .unwrap();
+                    let response_deoxys: #arg_struct = #arg_struct::call(&deoxys, &test.cmd, test.arg.clone()).await
+                        .with_context(|| format!("Error waiting for rpc call response from Deoxys in test {path}"))
+                        .unwrap();
 
-                assert_eq!(response_deoxys, response_alchemy);
+                    assert_eq!(response_deoxys, response_alchemy);
+                }
             }
         }       
     };

--- a/test/src/lib.rs
+++ b/test/src/lib.rs
@@ -4,14 +4,27 @@ mod tests {
     use serde::*;
     use rpc_call::*;
     use rpc_call_derive::*;
-    use rpc_test_attribute::*;
+    use rpc_test_attribute::*;    
 
     #[derive(Deserialize, Debug, PartialEq, RpcCall)]
-    struct BlockData {
-        block_hash: String,
-        block_number: u32,
+    struct GasPriceHolder {
+        price_in_wei: String,
     }
 
-    #[rpc_test(BlockData, "./unit/test.json")]
-    fn block_data_test() {}
+    #[derive(Deserialize, Debug, PartialEq, RpcCall)]
+    struct BlockWithTxHashes {
+        block_hash: Option<String>,
+        block_number: Option<u32>,
+        new_root: Option<String>,
+        l1_gas_price: GasPriceHolder,
+        parent_hash: String,
+        sequencer_address: String,
+        starknet_version: String,
+        status: String,
+        timestamp: u32,
+        transactions: Vec<String>
+    }
+
+    #[rpc_test(BlockWithTxHashes, "./unit/test_starknet_getBlockWithTxHashes.json")]
+    fn test_get_block_with_tx_hashes() {}
 }

--- a/test/unit/test.json
+++ b/test/unit/test.json
@@ -1,8 +1,0 @@
-{
-    "cmd": "starknet_blockHashAndNumber",
-    "arg": [],
-    "block_range": {
-        "start_inclusive": 0,
-        "stop_inclusive": 1
-    }
-}

--- a/test/unit/test_block_data.json
+++ b/test/unit/test_block_data.json
@@ -1,0 +1,8 @@
+{
+    "cmd": "starknet_blockHashAndNumber",
+    "arg": [],
+    "block_range": {
+        "start_inclusive": 0,
+        "stop_inclusive": 1
+    }
+}

--- a/test/unit/test_starknet_getBlockWithTxHashes.json
+++ b/test/unit/test_starknet_getBlockWithTxHashes.json
@@ -1,0 +1,20 @@
+{
+    "tests": [
+        {
+            "cmd": "starknet_getBlockWithTxHashes",
+            "arg": [ "latest" ],
+            "block_range": {
+                "start_inclusive": 0,
+                "stop_inclusive": 1
+            }
+        },
+        {
+            "cmd": "starknet_getBlockWithTxHashes",
+            "arg": [ "pending" ],
+            "block_range": {
+                "start_inclusive": 0,
+                "stop_inclusive": 1
+            }
+        }
+    ]
+}


### PR DESCRIPTION
Updated RPC testing library to allow for multiple RPC test call definitions in a single JSON file. This especially simplifies testing RPC calls with optional arguments / different call structures. More details on Starknet RPC call structure [here](https://playground.open-rpc.org/?uiSchema%5BappBar%5D%5Bui:splitView%5D=false&schemaUrl=https://raw.githubusercontent.com/starkware-libs/starknet-specs/master/api/starknet_api_openrpc.json&uiSchema%5BappBar%5D%5Bui:input%5D=false&uiSchema%5BappBar%5D%5Bui:darkMode%5D=true&uiSchema%5BappBar%5D%5Bui:examplesDropdown%5D=false).