### PR TITLE
Feat/debug output

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 .vscode
 *.code-workspace
 secret.json
+test.log

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -18,6 +18,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f26201604c87b1e01bd3d98f8d5d9a8fcbb815e8cedb41ffccbeb4bf593a35fe"
 
 [[package]]
+name = "android-tzdata"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e999941b234f3131b00bc13c22d06e8c5ff726d1b6318ac7eb276997bbb4fef0"
+
+[[package]]
+name = "android_system_properties"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "819e7219dbd41043ac279b19830f2efc897156490d7fd6ea916720117ee66311"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "anyhow"
 version = "1.0.79"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -128,6 +143,30 @@ name = "cfg-if"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
+
+[[package]]
+name = "chrono"
+version = "0.4.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f2c685bad3eb3d45a01354cedb7d5faa66194d1d58ba6e267a8de788f79db38"
+dependencies = [
+ "android-tzdata",
+ "iana-time-zone",
+ "js-sys",
+ "num-traits",
+ "wasm-bindgen",
+ "windows-targets 0.48.5",
+]
+
+[[package]]
+name = "colored"
+version = "2.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cbf2150cce219b664a8a70df7a1f933836724b503f8a413af9365b4dcc4d90b8"
+dependencies = [
+ "lazy_static",
+ "windows-sys 0.48.0",
+]
 
 [[package]]
 name = "concurrent-queue"
@@ -483,6 +522,29 @@ dependencies = [
 ]
 
 [[package]]
+name = "iana-time-zone"
+version = "0.1.59"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6a67363e2aa4443928ce15e57ebae94fd8949958fd1223c4cfc0cd473ad7539"
+dependencies = [
+ "android_system_properties",
+ "core-foundation-sys",
+ "iana-time-zone-haiku",
+ "js-sys",
+ "wasm-bindgen",
+ "windows-core",
+]
+
+[[package]]
+name = "iana-time-zone-haiku"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f31827a206f56af32e590ba56d5d2d085f558508192593743f16b2306495269f"
+dependencies = [
+ "cc",
+]
+
+[[package]]
 name = "idna"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -653,6 +715,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "lazy_static"
+version = "1.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
+
+[[package]]
 name = "libc"
 version = "0.2.151"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -698,6 +766,15 @@ dependencies = [
  "libc",
  "wasi",
  "windows-sys 0.48.0",
+]
+
+[[package]]
+name = "num-traits"
+version = "0.2.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "39e3200413f237f41ab11ad6d161bc7239c84dcb631773ccd7de3dfe4b5c267c"
+dependencies = [
+ "autocfg",
 ]
 
 [[package]]
@@ -915,6 +992,9 @@ name = "rpc_test"
 version = "0.1.0"
 dependencies = [
  "anyhow",
+ "chrono",
+ "colored",
+ "jsonrpsee",
  "serde",
  "serde_json",
 ]
@@ -1580,6 +1660,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0de2cfda980f21be5a7ed2eadb3e6fe074d56022bea2cdeb1a62eb220fc04188"
 dependencies = [
  "rustls-pki-types",
+]
+
+[[package]]
+name = "windows-core"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "33ab640c8d7e35bf8ba19b884ba838ceb4fba93a4e8c65a9059d08afcfc683d9"
+dependencies = [
+ "windows-targets 0.52.0",
 ]
 
 [[package]]

--- a/README.md
+++ b/README.md
@@ -57,19 +57,30 @@ Tests consist of two parts:
 *test config file format:*
 ```json
 {
-    "cmd": "starknet_blockHashAndNumber",
-    "arg": [],
-    "block_range": {
-        "start_inclusive": 0,
-        "stop_inclusive": 1
-    }
+    "tests": [
+        {
+            "cmd": "rp_method1",
+            "arg": [ "..." ],
+        },
+        {
+            "cmd": "rpc_method2",
+            "arg": [ ],
+            "block_range": {
+                "start_inclusive": 0,
+                "stop_inclusive": 1000
+            }
+        }
+    ]
 }
 ```
 
 config file fields:
+- `tests`: all the rpc calls to test against.
 - `cmd`: the rpc command to query the node with.
 - `arg`: the arguments used during the rpc call.
 - *`block_range`* **(optional)**: the range of starknet blocks to run the unit test against.
+
+Each test specified in `tests` will result in an RPC call to the specified Alchemy and Deoxys nodes, comparing each result. Tests marked with `block_range` will be run against each block in the specified range. Please note that this significantly lengthens test time and should only be used for non-trivial calls whose functioning might have been different in earlier versions of the blockchain.
 
 ### In `lib.rs`
 
@@ -95,3 +106,13 @@ mod tests {
     fn block_data_test() {}
 }
 ```
+
+## Structure Format
+
+> ⚠️ Structure members must have the **exact same name** as the json fields expected as an RPC call result.
+
+- For fields which are themselves a JSON object, use another struct to represent this sub-object.
+- For fields that might be optional, use `Option`.
+
+Try and test as many edge cases as possible. Ths mostly includes optional parameters. You can find a list
+of Starknet RPC call and their arguments / return data [here](https://playground.open-rpc.org/?uiSchema%5BappBar%5D%5Bui:splitView%5D=false&schemaUrl=https://raw.githubusercontent.com/starkware-libs/starknet-specs/master/api/starknet_api_openrpc.json&uiSchema%5BappBar%5D%5Bui:input%5D=false&uiSchema%5BappBar%5D%5Bui:darkMode%5D=true&uiSchema%5BappBar%5D%5Bui:examplesDropdown%5D=false)

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@
 
 # ⚙️ Ditto: Library to test and benchmark Kasar infra
 
-_A simple Rust RPC test utility for the [Deoxis](https://github.com/KasarLabs/deoxys) Starknet node._
+_A simple Rust RPC test utility for the [Deoxys](https://github.com/KasarLabs/deoxys) Starknet node._
 
 ## Getting started
 

--- a/rpc_test/Cargo.toml
+++ b/rpc_test/Cargo.toml
@@ -7,5 +7,8 @@ edition = "2021"
 
 [dependencies]
 anyhow = "1.0.79"
+chrono = "0.4.31"
+colored = "2.1.0"
+jsonrpsee = { version = "0.21.0", features = ["client"] }
 serde = "1.0.194"
 serde_json = "1.0.110"

--- a/rpc_test/src/lib.rs
+++ b/rpc_test/src/lib.rs
@@ -1,2 +1,96 @@
 pub mod test_config;
 pub mod test_data;
+
+use std::fs::OpenOptions;
+use std::io::Write;
+
+use anyhow::Context;
+use chrono::Local;
+use jsonrpsee::core::client::{ClientT, self};
+use jsonrpsee::http_client::HttpClient;
+use colored::Colorize;
+
+pub struct ClientInfo<'a> {
+    client: &'a HttpClient,
+    name: &'a str,
+    display_response: &'a str,
+    display_test: &'a str,
+    display_path: &'a str,
+}
+
+impl <'a> ClientInfo<'a> {
+    pub fn new(client: &'a HttpClient, name: &'a str, response: &'a str, test: &'a str, path: &'a str) -> Self{
+        ClientInfo { 
+            client: client,
+            name: name, 
+            display_response: response, 
+            display_test: test, 
+            display_path: path 
+        }
+    }
+}
+
+pub async fn client_response<'a, A>(client: &ClientInfo<'a>, cmd: &str, args: &Vec<String>) -> anyhow::Result<A>
+where
+    A: jsonrpsee::core::DeserializeOwned
+{
+    let response: Result<A, client::Error> = client.client.request(cmd, args.clone()).await;
+
+    match response {
+        Ok(response) => Ok(response),
+        Err(e) => handle_client_error(client, e),
+    }
+}
+
+fn handle_client_error<'a, A>(client: &ClientInfo<'a>, e: client::Error) -> anyhow::Result<A> 
+where
+    A: jsonrpsee::core::DeserializeOwned,
+{
+    let err_context = err_context(client);
+    let err_log = err_log(client);
+
+    let mut file = OpenOptions::new()
+        .append(true)
+        .create(true)
+        .open("./test.log")
+        .with_context(|| "Failed to open log file at ../../test/test.log")
+        .unwrap();
+
+    write!(file, "{}", err_log)?;
+
+    Err(e).with_context(|| err_context)
+}
+
+fn err_context(client: &ClientInfo) -> String {
+    format!(
+        "\
+            Error waiting for rpc call response from {} in test {}\n\n\
+            {}: {}\n\n\
+            {}: {}\
+        ",
+        client.name,
+        client.display_path.underline().blue(),
+        "RPC call".white().bold(),
+        client.display_test,
+        "Response format".white().bold(),
+        client.display_response
+    )
+}
+
+fn err_log(client: &ClientInfo) -> String {
+    let now = Local::now().format("%d-%m-%Y %H:%M:%S").to_string();
+
+    format!(
+        "\
+            {}\n\
+            Error waiting for rpc call response from {} in test {}\n\n\
+            RPC call: {}\n\n\
+            Response format: {}\n\n\
+        ",
+        now,
+        client.name,
+        client.display_path,
+        client.display_test,
+        client.display_response
+    )
+}

--- a/rpc_test/src/test_data.rs
+++ b/rpc_test/src/test_data.rs
@@ -4,6 +4,11 @@ use std::{fs::File, io::Read};
 
 #[derive(Deserialize, Debug, PartialEq)]
 pub struct TestData {
+    pub tests: Vec<Unit>
+}
+
+#[derive(Deserialize, Debug, PartialEq)]
+pub struct Unit {
     pub cmd: String,
     pub arg: Vec<String>,
     pub block_range: Option<BlockRange>,

--- a/rpc_test/src/test_data.rs
+++ b/rpc_test/src/test_data.rs
@@ -1,20 +1,20 @@
 use anyhow::Context;
-use serde::Deserialize;
+use serde::{Deserialize, Serialize};
 use std::{fs::File, io::Read};
 
-#[derive(Deserialize, Debug, PartialEq)]
+#[derive(Deserialize, Serialize, Debug, PartialEq, Clone)]
 pub struct TestData {
     pub tests: Vec<Unit>
 }
 
-#[derive(Deserialize, Debug, PartialEq)]
+#[derive(Deserialize, Serialize, Debug, PartialEq, Clone)]
 pub struct Unit {
     pub cmd: String,
     pub arg: Vec<String>,
     pub block_range: Option<BlockRange>,
 }
 
-#[derive(Deserialize, Debug, PartialEq)]
+#[derive(Deserialize, Serialize, Debug, PartialEq, Clone, Copy)]
 pub struct BlockRange {
     pub start_inclusive: u32,
     pub stop_inclusive: u32,

--- a/rpc_test_attribute/src/lib.rs
+++ b/rpc_test_attribute/src/lib.rs
@@ -53,27 +53,25 @@ pub fn rpc_test(args: TokenStream, input: TokenStream) -> TokenStream {
                     None => 0..=1,
                 };
                 let display_test = serde_json::to_string_pretty(&test).unwrap();
+                let info_alchemy = rpc_test::ClientInfo::new(
+                    &alchemy,
+                    "Alchemy",
+                    &display_test,
+                    &display_response,
+                    &path
+                );
+                let info_deoxys = rpc_test::ClientInfo::new(
+                    &deoxys,
+                    "Deoxys",
+                    &display_test,
+                    &display_response,
+                    &path
+                );
 
                 for _ in range {
-                    let response_alchemy: #arg_struct = #arg_struct::call(&alchemy, &test.cmd, test.arg.clone()).await
-                        .with_context(|| format!(
-                        "
-                            Error waiting for rpc call response from Alchemy in test {path}\n\
-                            RPC call: {display_test}\n\
-                            Response format: {display_response}
-                        "
-                        ))
-                        .unwrap();
+                    let response_alchemy: #arg_struct = rpc_test::client_response(&info_alchemy, &test.cmd, &test.arg).await.unwrap();
 
-                    let response_deoxys: #arg_struct = #arg_struct::call(&deoxys, &test.cmd, test.arg.clone()).await
-                        .with_context(|| format!(
-                        "\
-                            Error waiting for rpc call response from Deoxys in test {path}\n\
-                            RPC call: {display_test}\n\
-                            Response format: {display_response}
-                        "
-                        ))
-                        .unwrap();
+                    let response_deoxys: #arg_struct = rpc_test::client_response(&info_deoxys, &test.cmd, &test.arg).await.unwrap();
 
                     assert_eq!(response_deoxys, response_alchemy);
                 }

--- a/rpc_test_attribute/src/lib.rs
+++ b/rpc_test_attribute/src/lib.rs
@@ -46,21 +46,23 @@ pub fn rpc_test(args: TokenStream, input: TokenStream) -> TokenStream {
                 .with_context(|| format!("Could not retrieve test data from {path}"))
                 .unwrap();
 
-            let range = match test_data.block_range {
-                Some(range) => range.start_inclusive..=range.stop_inclusive,
-                None => 0..=1,
-            };
+            for test in test_data.tests {
+                let range = match test.block_range {
+                    Some(range) => range.start_inclusive..=range.stop_inclusive,
+                    None => 0..=1,
+                };
 
-            for _ in range {
-                let response_alchemy: #arg_struct = #arg_struct::call(&alchemy, &test_data.cmd, test_data.arg.clone()).await
-                    .with_context(|| format!("Error waiting for rpc call response from Alchemy in test {path}"))
-                    .unwrap();
+                for _ in range {
+                    let response_alchemy: #arg_struct = #arg_struct::call(&alchemy, &test.cmd, test.arg.clone()).await
+                        .with_context(|| format!("Error waiting for rpc call response from Alchemy in test {path}"))
+                        .unwrap();
 
-                let response_deoxys: #arg_struct = #arg_struct::call(&deoxys, &test_data.cmd, test_data.arg.clone()).await
-                    .with_context(|| format!("Error waiting for rpc call response from Deoxys in test {path}"))
-                    .unwrap();
+                    let response_deoxys: #arg_struct = #arg_struct::call(&deoxys, &test.cmd, test.arg.clone()).await
+                        .with_context(|| format!("Error waiting for rpc call response from Deoxys in test {path}"))
+                        .unwrap();
 
-                assert_eq!(response_deoxys, response_alchemy);
+                    assert_eq!(response_deoxys, response_alchemy);
+                }
             }
         }       
     };

--- a/test/src/lib.rs
+++ b/test/src/lib.rs
@@ -4,14 +4,16 @@ mod tests {
     use serde::*;
     use rpc_call::*;
     use rpc_call_derive::*;
-    use rpc_test_attribute::*;    
+    use rpc_test_attribute::*;
 
-    #[derive(Deserialize, Debug, PartialEq, RpcCall)]
+    #[derive(Deserialize, Serialize, Debug, PartialEq, RpcCall, Default)]
     struct GasPriceHolder {
         price_in_wei: String,
     }
 
-    #[derive(Deserialize, Debug, PartialEq, RpcCall)]
+    // TODO: currently only checks against `latest` and `pending` blocks.
+    // still need to add tests for specific block hash
+    #[derive(Deserialize, Serialize, Debug, PartialEq, RpcCall, Default)]
     struct BlockWithTxHashes {
         block_hash: Option<String>,
         block_number: Option<u32>,

--- a/test/src/lib.rs
+++ b/test/src/lib.rs
@@ -4,14 +4,27 @@ mod tests {
     use serde::*;
     use rpc_call::*;
     use rpc_call_derive::*;
-    use rpc_test_attribute::*;
+    use rpc_test_attribute::*;    
 
     #[derive(Deserialize, Debug, PartialEq, RpcCall)]
-    struct BlockData {
-        block_hash: String,
-        block_number: u32,
+    struct GasPriceHolder {
+        price_in_wei: String,
     }
 
-    #[rpc_test(BlockData, "./unit/test.json")]
-    fn block_data_test() {}
+    #[derive(Deserialize, Debug, PartialEq, RpcCall)]
+    struct BlockWithTxHashes {
+        block_hash: Option<String>,
+        block_number: Option<u32>,
+        new_root: Option<String>,
+        l1_gas_price: GasPriceHolder,
+        parent_hash: String,
+        sequencer_address: String,
+        starknet_version: String,
+        status: String,
+        timestamp: u32,
+        transactions: Vec<String>
+    }
+
+    #[rpc_test(BlockWithTxHashes, "./unit/test_starknet_getBlockWithTxHashes.json")]
+    fn test_get_block_with_tx_hashes() {}
 }

--- a/test/unit/test.json
+++ b/test/unit/test.json
@@ -1,8 +1,0 @@
-{
-    "cmd": "starknet_blockHashAndNumber",
-    "arg": [],
-    "block_range": {
-        "start_inclusive": 0,
-        "stop_inclusive": 1
-    }
-}

--- a/test/unit/test_block_data.json
+++ b/test/unit/test_block_data.json
@@ -1,0 +1,8 @@
+{
+    "cmd": "starknet_blockHashAndNumber",
+    "arg": [],
+    "block_range": {
+        "start_inclusive": 0,
+        "stop_inclusive": 1
+    }
+}

--- a/test/unit/test_starknet_getBlockWithTxHashes.json
+++ b/test/unit/test_starknet_getBlockWithTxHashes.json
@@ -1,0 +1,20 @@
+{
+    "tests": [
+        {
+            "cmd": "starknet_getBlockWithTxHashes",
+            "arg": [ "latest" ],
+            "block_range": {
+                "start_inclusive": 0,
+                "stop_inclusive": 1
+            }
+        },
+        {
+            "cmd": "starknet_getBlockWithTxHashes",
+            "arg": [ "pending" ],
+            "block_range": {
+                "start_inclusive": 0,
+                "stop_inclusive": 1
+            }
+        }
+    ]
+}


### PR DESCRIPTION
Added better debug output and error logging to Ditto

RPC calls and result format are now displayed in JSON format whenever a test fails. The same info is saved to `test/test.log` with a timestamp.