### PR TITLE
test: :test_tube: Adding multiples tests for estimateFee RPC Call

### DIFF
--- a/test/Cargo.toml
+++ b/test/Cargo.toml
@@ -18,3 +18,4 @@ tokio = { version = "1", features = ["full", "test-util"] }
 rpc_test = { path = "../rpc_test/" }
 rpc_test_attribute ={ path = "../rpc_test_attribute/" }
 starknet = { git = "https://github.com/xJonathanLEI/starknet-rs.git", rev = "a35ce22", default-features = false }
+starknet-providers = "0.8.0"

--- a/test/Cargo.toml
+++ b/test/Cargo.toml
@@ -18,4 +18,5 @@ tokio = { version = "1", features = ["full", "test-util"] }
 rpc_test = { path = "../rpc_test/" }
 rpc_test_attribute ={ path = "../rpc_test_attribute/" }
 starknet = { git = "https://github.com/xJonathanLEI/starknet-rs.git", rev = "a35ce22", default-features = false }
-starknet-providers = "0.8.0"
+starknet-core = { git = "https://github.com/xJonathanLEI/starknet-rs.git", rev = "a35ce22", default-features = false }
+starknet-providers = { git = "https://github.com/xJonathanLEI/starknet-rs.git", rev = "a35ce22", default-features = false }

--- a/test/tests/test_estimate_fee.rs
+++ b/test/tests/test_estimate_fee.rs
@@ -1,0 +1,200 @@
+#![feature(assert_matches)]
+
+use rpc_test::test_config::TestConfig;
+use starknet::{providers::{
+    jsonrpc::{HttpTransport, JsonRpcClient},
+    Provider, ProviderError, StarknetErrorWithMessage, MaybeUnknownErrorCode
+}, core::types::{BlockId, FieldElement, StarknetError, BlockTag, BroadcastedTransaction, BroadcastedInvokeTransaction}};
+use starknet::core::utils::get_selector_from_name;
+use url::Url;
+use std::assert_matches::assert_matches;
+//use starknet_providers::ProviderError::StarknetError as StarknetProviderError;
+
+const ACCOUNT_CONTRACT: &str = "";
+const TEST_CONTRACT_ADDRESS: &str = "";
+
+
+#[tokio::test]
+async fn fail_non_existing_block() {
+    let config = TestConfig::new("./secret.json").unwrap();
+    let deoxys = JsonRpcClient::new(HttpTransport::new(
+        Url::parse(&config.deoxys).unwrap()
+    ));
+
+    let ok_invoke_transaction = BroadcastedTransaction::Invoke(BroadcastedInvokeTransaction {
+        max_fee: FieldElement::ZERO,
+        signature: vec![],
+        nonce: FieldElement::ZERO,
+        sender_address: FieldElement::from_hex_be(ACCOUNT_CONTRACT).unwrap(),
+        calldata: vec![
+            FieldElement::from_hex_be(TEST_CONTRACT_ADDRESS).unwrap(),
+            get_selector_from_name("sqrt").unwrap(),
+            FieldElement::from_hex_be("1").unwrap(),
+            FieldElement::from(81u8),
+        ],
+        is_query: true,
+    });
+
+    assert_matches!(
+        deoxys.estimate_fee(&vec![ok_invoke_transaction], BlockId::Hash(FieldElement::ZERO)).await,
+        Err(ProviderError::StarknetError(StarknetErrorWithMessage { code: MaybeUnknownErrorCode::Known(code), .. })) if code == StarknetError::BlockNotFound
+    );
+
+}
+
+#[tokio::test]
+async fn fail_if_one_txn_cannot_be_executed() {
+    let config = TestConfig::new("./secret.json").unwrap();
+    let deoxys = JsonRpcClient::new(HttpTransport::new(
+        Url::parse(&config.deoxys).unwrap()
+    ));
+
+    let alchemy = JsonRpcClient::new(HttpTransport::new(
+        Url::parse(&config.alchemy).unwrap()
+    ));
+
+    let bad_invoke_transaction = BroadcastedTransaction::Invoke(BroadcastedInvokeTransaction {
+        max_fee: FieldElement::default(),
+        nonce: FieldElement::ZERO,
+        sender_address: FieldElement::default(),
+        signature: vec![],
+        calldata: vec![FieldElement::from_hex_be("0x0").unwrap()],
+        is_query: true,
+    });
+
+    let ok_invoke_transaction = BroadcastedTransaction::Invoke(BroadcastedInvokeTransaction {
+        max_fee: FieldElement::ZERO,
+        signature: vec![],
+        nonce: FieldElement::ZERO,
+        sender_address: FieldElement::from_hex_be(ACCOUNT_CONTRACT).unwrap(),
+        calldata: vec![
+            FieldElement::from_hex_be(TEST_CONTRACT_ADDRESS).unwrap(),
+            get_selector_from_name("sqrt").unwrap(),
+            FieldElement::from_hex_be("1").unwrap(),
+            FieldElement::from(81u8),
+        ],
+        is_query: true,
+    });
+
+    let alchemy_bad_invoke_transaction = BroadcastedTransaction::Invoke(BroadcastedInvokeTransaction {
+        max_fee: FieldElement::default(),
+        nonce: FieldElement::ZERO,
+        sender_address: FieldElement::default(),
+        signature: vec![],
+        calldata: vec![FieldElement::from_hex_be("0x0").unwrap()],
+        is_query: true,
+    });
+
+    let alchemy_ok_invoke_transaction = BroadcastedTransaction::Invoke(BroadcastedInvokeTransaction {
+        max_fee: FieldElement::ZERO,
+        signature: vec![],
+        nonce: FieldElement::ZERO,
+        sender_address: FieldElement::from_hex_be(ACCOUNT_CONTRACT).unwrap(),
+        calldata: vec![
+            FieldElement::from_hex_be(TEST_CONTRACT_ADDRESS).unwrap(),
+            get_selector_from_name("sqrt").unwrap(),
+            FieldElement::from_hex_be("1").unwrap(),
+            FieldElement::from(81u8),
+        ],
+        is_query: true,
+    });
+
+    // assert_matches!(
+    //     deoxys.estimate_fee(&vec![
+    //         bad_invoke_transaction,
+    //         ok_invoke_transaction,
+    //     ], BlockId::Tag(BlockTag::Latest)).await,
+    //     Err(ProviderError::StarknetError(StarknetErrorWithMessage { code: MaybeUnknownErrorCode::Known(code), .. })) if code == StarknetError::ContractError
+    // );
+
+    let deoxys_ok_result = deoxys.estimate_fee(&vec![ok_invoke_transaction], BlockId::Tag(BlockTag::Latest)).await;
+    let deoxys_bad_result = deoxys.estimate_fee(&vec![bad_invoke_transaction], BlockId::Tag(BlockTag::Latest)).await;
+    
+    let alchemy_ok_result = alchemy.estimate_fee(&vec![alchemy_ok_invoke_transaction], BlockId::Tag(BlockTag::Latest)).await;
+    let alchemy_bad_result = alchemy.estimate_fee(&vec![alchemy_bad_invoke_transaction], BlockId::Tag(BlockTag::Latest)).await;
+    
+    assert_matches!(
+        (deoxys_ok_result, alchemy_ok_result),
+        (Ok(_), Ok(_))
+    );
+
+    assert_matches!(
+        (deoxys_bad_result, alchemy_bad_result),
+        (Ok(_), Ok(_))
+    );
+
+}
+
+#[tokio::test]
+async fn works_ok(){
+    let config = TestConfig::new("./secret.json").unwrap();
+    let deoxys = JsonRpcClient::new(HttpTransport::new(
+        Url::parse(&config.deoxys).unwrap()
+    ));
+
+    let alchemy = JsonRpcClient::new(HttpTransport::new(
+        Url::parse(&config.alchemy).unwrap()
+    ));
+
+    let tx = BroadcastedInvokeTransaction {
+        max_fee: FieldElement::ZERO,
+        signature: vec![],
+        nonce: FieldElement::ZERO,
+        sender_address: FieldElement::from_hex_be(ACCOUNT_CONTRACT).unwrap(),
+        calldata: vec![
+            FieldElement::from_hex_be(TEST_CONTRACT_ADDRESS).unwrap(),
+            get_selector_from_name("sqrt").unwrap(),
+            FieldElement::from_hex_be("1").unwrap(),
+            FieldElement::from(81u8),
+        ],
+        is_query: true,
+    };
+
+    let tx_alchemy = BroadcastedInvokeTransaction {
+        max_fee: FieldElement::ZERO,
+        signature: vec![],
+        nonce: FieldElement::ZERO,
+        sender_address: FieldElement::from_hex_be(ACCOUNT_CONTRACT).unwrap(),
+        calldata: vec![
+            FieldElement::from_hex_be(TEST_CONTRACT_ADDRESS).unwrap(),
+            get_selector_from_name("sqrt").unwrap(),
+            FieldElement::from_hex_be("1").unwrap(),
+            FieldElement::from(81u8),
+        ],
+        is_query: true,
+    };
+
+    let invoke_transaction_deoxys = BroadcastedTransaction::Invoke(tx.clone());
+    let invoke_transaction_alchemy = BroadcastedTransaction::Invoke(tx_alchemy.clone());
+
+    let invoke_transaction_2 =
+        BroadcastedTransaction::Invoke(BroadcastedInvokeTransaction { nonce: FieldElement::ONE, ..tx });
+
+    let invoke_transaction_3 =
+        BroadcastedTransaction::Invoke(BroadcastedInvokeTransaction { nonce: FieldElement::ONE, ..tx_alchemy });
+
+    let deoxys_estimates =
+        deoxys.estimate_fee(&vec![invoke_transaction_deoxys, invoke_transaction_2], BlockId::Tag(BlockTag::Latest)).await.unwrap();
+    
+    let alchemy_estimates =
+        alchemy.estimate_fee(&vec![invoke_transaction_alchemy, invoke_transaction_3], BlockId::Tag(BlockTag::Latest)).await.unwrap();
+
+    // TODO: instead execute the tx and check that the actual fee are the same as the estimated ones
+    assert_eq!(deoxys_estimates.len(), 2);
+    assert_eq!(deoxys_estimates[0].overall_fee, 420);
+    assert_eq!(deoxys_estimates[1].overall_fee, 420);
+    
+    assert_eq!(deoxys_estimates[0].gas_consumed, 0);
+    assert_eq!(deoxys_estimates[1].gas_consumed, 0);
+
+    assert_eq!(deoxys_estimates.len(), alchemy_estimates.len());
+    assert_eq!(deoxys_estimates[0].overall_fee, alchemy_estimates[0].overall_fee);
+    assert_eq!(deoxys_estimates[1].overall_fee, alchemy_estimates[1].overall_fee);
+    
+    assert_eq!(deoxys_estimates[0].gas_consumed, alchemy_estimates[0].gas_consumed);
+    assert_eq!(deoxys_estimates[1].gas_consumed, alchemy_estimates[1].gas_consumed);
+
+    //Ok(())
+}
+
+

--- a/test/tests/test_estimate_fee.rs
+++ b/test/tests/test_estimate_fee.rs
@@ -1,30 +1,26 @@
 #![feature(assert_matches)]
 
 use rpc_test::test_config::TestConfig;
-use starknet::{providers::{
+use starknet_core::types::{
+    BlockId, BlockTag, BroadcastedInvokeTransaction, BroadcastedTransaction, FieldElement,
+    StarknetError,
+};
+use starknet_core::utils::get_selector_from_name;
+use starknet_providers::{
     jsonrpc::{HttpTransport, JsonRpcClient},
-    Provider, ProviderError, StarknetErrorWithMessage, MaybeUnknownErrorCode
-}, core::types::{BlockId, FieldElement, StarknetError, BlockTag, BroadcastedTransaction, BroadcastedInvokeTransaction}};
-use starknet::core::utils::get_selector_from_name;
-use url::Url;
+    MaybeUnknownErrorCode, Provider, ProviderError, StarknetErrorWithMessage,
+};
 use std::assert_matches::assert_matches;
-//use starknet_providers::ProviderError::StarknetError as StarknetProviderError;
+use url::Url;
 
 const ACCOUNT_CONTRACT: &str = "";
 const TEST_CONTRACT_ADDRESS: &str = "";
 
-
-#[tokio::test]
-async fn fail_non_existing_block() {
-    let config = TestConfig::new("./secret.json").unwrap();
-    let deoxys = JsonRpcClient::new(HttpTransport::new(
-        Url::parse(&config.deoxys).unwrap()
-    ));
-
-    let ok_invoke_transaction = BroadcastedTransaction::Invoke(BroadcastedInvokeTransaction {
+fn load_ok_invoke_transaction(nonce: FieldElement) -> BroadcastedTransaction {
+    BroadcastedTransaction::Invoke(BroadcastedInvokeTransaction {
         max_fee: FieldElement::ZERO,
         signature: vec![],
-        nonce: FieldElement::ZERO,
+        nonce: nonce,
         sender_address: FieldElement::from_hex_be(ACCOUNT_CONTRACT).unwrap(),
         calldata: vec![
             FieldElement::from_hex_be(TEST_CONTRACT_ADDRESS).unwrap(),
@@ -33,168 +29,86 @@ async fn fail_non_existing_block() {
             FieldElement::from(81u8),
         ],
         is_query: true,
-    });
+    })
+}
+
+fn load_bad_invoke_transaction() -> BroadcastedTransaction {
+    BroadcastedTransaction::Invoke(BroadcastedInvokeTransaction {
+        max_fee: FieldElement::default(),
+        nonce: FieldElement::ZERO,
+        sender_address: FieldElement::default(),
+        signature: vec![],
+        calldata: vec![FieldElement::from_hex_be("0x0").unwrap()],
+        is_query: true,
+    })
+}
+
+#[tokio::test]
+async fn fail_non_existing_block() {
+    let config = TestConfig::new("./secret.json").unwrap();
+    let deoxys = JsonRpcClient::new(HttpTransport::new(Url::parse(&config.deoxys).unwrap()));
+
+    let ok_invoke_transaction = load_ok_invoke_transaction(FieldElement::ZERO);
 
     assert_matches!(
         deoxys.estimate_fee(&vec![ok_invoke_transaction], BlockId::Hash(FieldElement::ZERO)).await,
         Err(ProviderError::StarknetError(StarknetErrorWithMessage { code: MaybeUnknownErrorCode::Known(code), .. })) if code == StarknetError::BlockNotFound
     );
-
 }
 
 #[tokio::test]
 async fn fail_if_one_txn_cannot_be_executed() {
     let config = TestConfig::new("./secret.json").unwrap();
-    let deoxys = JsonRpcClient::new(HttpTransport::new(
-        Url::parse(&config.deoxys).unwrap()
-    ));
+    let deoxys = JsonRpcClient::new(HttpTransport::new(Url::parse(&config.deoxys).unwrap()));
+    let alchemy = JsonRpcClient::new(HttpTransport::new(Url::parse(&config.alchemy).unwrap()));
 
-    let alchemy = JsonRpcClient::new(HttpTransport::new(
-        Url::parse(&config.alchemy).unwrap()
-    ));
+    let bad_invoke_transaction = load_bad_invoke_transaction();
 
-    let bad_invoke_transaction = BroadcastedTransaction::Invoke(BroadcastedInvokeTransaction {
-        max_fee: FieldElement::default(),
-        nonce: FieldElement::ZERO,
-        sender_address: FieldElement::default(),
-        signature: vec![],
-        calldata: vec![FieldElement::from_hex_be("0x0").unwrap()],
-        is_query: true,
-    });
+    let result_deoxys = deoxys
+        .estimate_fee(
+            vec![bad_invoke_transaction.clone()],
+            BlockId::Tag(BlockTag::Latest),
+        )
+        .await
+        .unwrap();
 
-    let ok_invoke_transaction = BroadcastedTransaction::Invoke(BroadcastedInvokeTransaction {
-        max_fee: FieldElement::ZERO,
-        signature: vec![],
-        nonce: FieldElement::ZERO,
-        sender_address: FieldElement::from_hex_be(ACCOUNT_CONTRACT).unwrap(),
-        calldata: vec![
-            FieldElement::from_hex_be(TEST_CONTRACT_ADDRESS).unwrap(),
-            get_selector_from_name("sqrt").unwrap(),
-            FieldElement::from_hex_be("1").unwrap(),
-            FieldElement::from(81u8),
-        ],
-        is_query: true,
-    });
+    let result_alchemy = alchemy
+        .estimate_fee(vec![bad_invoke_transaction], BlockId::Tag(BlockTag::Latest))
+        .await
+        .unwrap();
 
-    let alchemy_bad_invoke_transaction = BroadcastedTransaction::Invoke(BroadcastedInvokeTransaction {
-        max_fee: FieldElement::default(),
-        nonce: FieldElement::ZERO,
-        sender_address: FieldElement::default(),
-        signature: vec![],
-        calldata: vec![FieldElement::from_hex_be("0x0").unwrap()],
-        is_query: true,
-    });
-
-    let alchemy_ok_invoke_transaction = BroadcastedTransaction::Invoke(BroadcastedInvokeTransaction {
-        max_fee: FieldElement::ZERO,
-        signature: vec![],
-        nonce: FieldElement::ZERO,
-        sender_address: FieldElement::from_hex_be(ACCOUNT_CONTRACT).unwrap(),
-        calldata: vec![
-            FieldElement::from_hex_be(TEST_CONTRACT_ADDRESS).unwrap(),
-            get_selector_from_name("sqrt").unwrap(),
-            FieldElement::from_hex_be("1").unwrap(),
-            FieldElement::from(81u8),
-        ],
-        is_query: true,
-    });
-
-    // assert_matches!(
-    //     deoxys.estimate_fee(&vec![
-    //         bad_invoke_transaction,
-    //         ok_invoke_transaction,
-    //     ], BlockId::Tag(BlockTag::Latest)).await,
-    //     Err(ProviderError::StarknetError(StarknetErrorWithMessage { code: MaybeUnknownErrorCode::Known(code), .. })) if code == StarknetError::ContractError
-    // );
-
-    let deoxys_ok_result = deoxys.estimate_fee(&vec![ok_invoke_transaction], BlockId::Tag(BlockTag::Latest)).await;
-    let deoxys_bad_result = deoxys.estimate_fee(&vec![bad_invoke_transaction], BlockId::Tag(BlockTag::Latest)).await;
-    
-    let alchemy_ok_result = alchemy.estimate_fee(&vec![alchemy_ok_invoke_transaction], BlockId::Tag(BlockTag::Latest)).await;
-    let alchemy_bad_result = alchemy.estimate_fee(&vec![alchemy_bad_invoke_transaction], BlockId::Tag(BlockTag::Latest)).await;
-    
-    assert_matches!(
-        (deoxys_ok_result, alchemy_ok_result),
-        (Ok(_), Ok(_))
-    );
-
-    assert_matches!(
-        (deoxys_bad_result, alchemy_bad_result),
-        (Ok(_), Ok(_))
-    );
-
+    assert_eq!(result_deoxys, result_alchemy);
 }
 
 #[tokio::test]
-async fn works_ok(){
+async fn works_ok() {
     let config = TestConfig::new("./secret.json").unwrap();
-    let deoxys = JsonRpcClient::new(HttpTransport::new(
-        Url::parse(&config.deoxys).unwrap()
-    ));
+    let deoxys = JsonRpcClient::new(HttpTransport::new(Url::parse(&config.deoxys).unwrap()));
+    let alchemy = JsonRpcClient::new(HttpTransport::new(Url::parse(&config.alchemy).unwrap()));
 
-    let alchemy = JsonRpcClient::new(HttpTransport::new(
-        Url::parse(&config.alchemy).unwrap()
-    ));
+    let ok_deoxys_invoke = load_ok_invoke_transaction(FieldElement::ZERO);
+    let ok_deoxys_invoke_1 = load_ok_invoke_transaction(FieldElement::ONE);
+    let ok_deoxys_invoke_2 = load_ok_invoke_transaction(FieldElement::TWO);
 
-    let tx = BroadcastedInvokeTransaction {
-        max_fee: FieldElement::ZERO,
-        signature: vec![],
-        nonce: FieldElement::ZERO,
-        sender_address: FieldElement::from_hex_be(ACCOUNT_CONTRACT).unwrap(),
-        calldata: vec![
-            FieldElement::from_hex_be(TEST_CONTRACT_ADDRESS).unwrap(),
-            get_selector_from_name("sqrt").unwrap(),
-            FieldElement::from_hex_be("1").unwrap(),
-            FieldElement::from(81u8),
-        ],
-        is_query: true,
-    };
+    let ok_alchemy_invoke = load_ok_invoke_transaction(FieldElement::ZERO);
+    let ok_alchemy_invoke_1 = load_ok_invoke_transaction(FieldElement::ONE);
+    let ok_alchemy_invoke_2 = load_ok_invoke_transaction(FieldElement::TWO);
 
-    let tx_alchemy = BroadcastedInvokeTransaction {
-        max_fee: FieldElement::ZERO,
-        signature: vec![],
-        nonce: FieldElement::ZERO,
-        sender_address: FieldElement::from_hex_be(ACCOUNT_CONTRACT).unwrap(),
-        calldata: vec![
-            FieldElement::from_hex_be(TEST_CONTRACT_ADDRESS).unwrap(),
-            get_selector_from_name("sqrt").unwrap(),
-            FieldElement::from_hex_be("1").unwrap(),
-            FieldElement::from(81u8),
-        ],
-        is_query: true,
-    };
+    let deoxys_estimates = deoxys
+        .estimate_fee(
+            &vec![ok_deoxys_invoke, ok_deoxys_invoke_1, ok_deoxys_invoke_2],
+            BlockId::Tag(BlockTag::Latest),
+        )
+        .await
+        .unwrap();
 
-    let invoke_transaction_deoxys = BroadcastedTransaction::Invoke(tx.clone());
-    let invoke_transaction_alchemy = BroadcastedTransaction::Invoke(tx_alchemy.clone());
+    let alchemy_estimates = alchemy
+        .estimate_fee(
+            &vec![ok_alchemy_invoke, ok_alchemy_invoke_1, ok_alchemy_invoke_2],
+            BlockId::Tag(BlockTag::Latest),
+        )
+        .await
+        .unwrap();
 
-    let invoke_transaction_2 =
-        BroadcastedTransaction::Invoke(BroadcastedInvokeTransaction { nonce: FieldElement::ONE, ..tx });
-
-    let invoke_transaction_3 =
-        BroadcastedTransaction::Invoke(BroadcastedInvokeTransaction { nonce: FieldElement::ONE, ..tx_alchemy });
-
-    let deoxys_estimates =
-        deoxys.estimate_fee(&vec![invoke_transaction_deoxys, invoke_transaction_2], BlockId::Tag(BlockTag::Latest)).await.unwrap();
-    
-    let alchemy_estimates =
-        alchemy.estimate_fee(&vec![invoke_transaction_alchemy, invoke_transaction_3], BlockId::Tag(BlockTag::Latest)).await.unwrap();
-
-    // TODO: instead execute the tx and check that the actual fee are the same as the estimated ones
-    assert_eq!(deoxys_estimates.len(), 2);
-    assert_eq!(deoxys_estimates[0].overall_fee, 420);
-    assert_eq!(deoxys_estimates[1].overall_fee, 420);
-    
-    assert_eq!(deoxys_estimates[0].gas_consumed, 0);
-    assert_eq!(deoxys_estimates[1].gas_consumed, 0);
-
-    assert_eq!(deoxys_estimates.len(), alchemy_estimates.len());
-    assert_eq!(deoxys_estimates[0].overall_fee, alchemy_estimates[0].overall_fee);
-    assert_eq!(deoxys_estimates[1].overall_fee, alchemy_estimates[1].overall_fee);
-    
-    assert_eq!(deoxys_estimates[0].gas_consumed, alchemy_estimates[0].gas_consumed);
-    assert_eq!(deoxys_estimates[1].gas_consumed, alchemy_estimates[1].gas_consumed);
-
-    //Ok(())
+    assert_eq!(deoxys_estimates, alchemy_estimates)
 }
-
-


### PR DESCRIPTION
Adding following tests to deoxys RPC Call :

estimateFee

# What is the current behavior?

Add tests for RPC call, i might check some data types later to ensure implementation is reliable.

# Does this introduce a breaking change?

NO

# Other information
