### PR TITLE
:white_check_mark: Added tests for `starknet_getTransactionByHash`

### DIFF
--- a/unit_tests/src/constants.rs
+++ b/unit_tests/src/constants.rs
@@ -86,6 +86,20 @@ pub const TRANSACTION_INVOKE: &str = "0x05d087d23ffb5b63f7a19ee6dfe0227d04fbcb0d
 pub const TRANSACTION_L1_HANDLER: &str = "0x0618051a7342133153f23df4b6d3baa6f3a933e00956b3ee621c9af76ed2cef0";
 
 ///
+/// Random Starknet DECLARE transaction accepted on L1
+/// 
+/// Details concerning this transaction can be found on [StarkScan](https://starkscan.co/tx/0x056c0723ef6cde62f589bbf7c5c40897b6e3d9c13e960c5e7f28276d8e9c3229)
+/// 
+pub const TRANSACTION_DECLARE: &str = "0x056c0723ef6cde62f589bbf7c5c40897b6e3d9c13e960c5e7f28276d8e9c3229";
+
+///
+/// Random Starknet DEPLOY transaction accepted on L1
+/// 
+/// Details concerning this transaction can be found on [StarkScan](https://starkscan.co/tx/0x056617d1e694083e27ecc1fcf46eb098cdeff26f223ae17612ebc746a796d9ad)
+/// 
+pub const TRANSACTION_DEPLOY_ACCOUNT: &str = "0x056617d1e694083e27ecc1fcf46eb098cdeff26f223ae17612ebc746a796d9ad";
+
+///
 /// Random reverted Starknet transaction
 /// 
 /// Details concerning this transaction can be found on [StarkScan](https://starkscan.co/tx/0x016ed559467c50c12f225f348ca8895d54b91a499ad6f856cb6086e317c120ca)

--- a/unit_tests/src/constants.rs
+++ b/unit_tests/src/constants.rs
@@ -76,7 +76,7 @@ pub const BLOCK_LEGACY: u64 = 2891;
 /// 
 /// Details concerning this transaction can be found on [StarkScan](https://starkscan.co/tx/0x05d087d23ffb5b63f7a19ee6dfe0227d04fbcb0d0ccbfec5ec52c482429ab3f5)
 /// 
-pub const TRANSACTION_ACCEPTED: &str = "0x05d087d23ffb5b63f7a19ee6dfe0227d04fbcb0d0ccbfec5ec52c482429ab3f5";
+pub const TRANSACTION_INVOKE: &str = "0x05d087d23ffb5b63f7a19ee6dfe0227d04fbcb0d0ccbfec5ec52c482429ab3f5";
 
 ///
 /// Random reverted Starknet transaction

--- a/unit_tests/src/constants.rs
+++ b/unit_tests/src/constants.rs
@@ -71,6 +71,20 @@ pub const CONTRACT_ACCOUNT_PROXY: &str = "0x05d7f4d55795b56ceb4dd93febe17954c7cf
 pub const CONTRACT_LEGACY: &str = "0x07076931c19d0ef52b847f9412c90a2ef999ff028f1005d2d069343061762fb7";
 pub const BLOCK_LEGACY: u64 = 2891;
 
+///
+/// Random Starknet transaction accepted on L1
+/// 
+/// Details concerning this transaction can be found on [StarkScan](https://starkscan.co/tx/0x05d087d23ffb5b63f7a19ee6dfe0227d04fbcb0d0ccbfec5ec52c482429ab3f5)
+/// 
+pub const TRANSACTION_ACCEPTED: &str = "0x05d087d23ffb5b63f7a19ee6dfe0227d04fbcb0d0ccbfec5ec52c482429ab3f5";
+
+///
+/// Random reverted Starknet transaction
+/// 
+/// Details concerning this transaction can be found on [StarkScan](https://starkscan.co/tx/0x016ed559467c50c12f225f348ca8895d54b91a499ad6f856cb6086e317c120ca)
+/// 
+pub const TRANSACTION_REVERTED: &str = "0x016ed559467c50c12f225f348ca8895d54b91a499ad6f856cb6086e317c120ca";
+
 pub const ACCOUNT_CONTRACT: &str = "";
 pub const TEST_CONTRACT_ADDRESS: &str = "";
 pub const CAIRO_1_ACCOUNT_CONTRACT_CLASS_HASH: &str = "";

--- a/unit_tests/src/constants.rs
+++ b/unit_tests/src/constants.rs
@@ -72,11 +72,18 @@ pub const CONTRACT_LEGACY: &str = "0x07076931c19d0ef52b847f9412c90a2ef999ff028f1
 pub const BLOCK_LEGACY: u64 = 2891;
 
 ///
-/// Random Starknet transaction accepted on L1
+/// Random Starknet INVOKE transaction accepted on L1
 /// 
 /// Details concerning this transaction can be found on [StarkScan](https://starkscan.co/tx/0x05d087d23ffb5b63f7a19ee6dfe0227d04fbcb0d0ccbfec5ec52c482429ab3f5)
 /// 
 pub const TRANSACTION_INVOKE: &str = "0x05d087d23ffb5b63f7a19ee6dfe0227d04fbcb0d0ccbfec5ec52c482429ab3f5";
+
+///
+/// Random Starknet L1_HANDLER transaction accepted on L1
+/// 
+/// Details concerning this transaction can be found on [StarkScan](https://starkscan.co/tx/0x0618051a7342133153f23df4b6d3baa6f3a933e00956b3ee621c9af76ed2cef0)
+/// 
+pub const TRANSACTION_L1_HANDLER: &str = "0x0618051a7342133153f23df4b6d3baa6f3a933e00956b3ee621c9af76ed2cef0";
 
 ///
 /// Random reverted Starknet transaction

--- a/unit_tests/tests/test_get_transaction_by_hash.rs
+++ b/unit_tests/tests/test_get_transaction_by_hash.rs
@@ -7,6 +7,12 @@ use common::*;
 use starknet_core::types::{FieldElement, StarknetError, Transaction};
 use starknet_providers::{JsonRpcClient, jsonrpc::HttpTransport, Provider, StarknetErrorWithMessage, ProviderError, MaybeUnknownErrorCode};
 
+///
+/// Unit test for `starknet_getTransactionByHash`
+/// 
+/// purpose: call getTransactionHash on non existent transaction.
+/// fail case: transaction does not exist.
+/// 
 #[rstest]
 #[tokio::test]
 async fn fail_non_existing_transaction(clients: HashMap<String, JsonRpcClient<HttpTransport>>) {
@@ -25,6 +31,12 @@ async fn fail_non_existing_transaction(clients: HashMap<String, JsonRpcClient<Ht
     )));
 }
 
+///
+/// Unit test for `starknet_getTransactionByHash`
+/// 
+/// purpose: call getTransactionHash on INVOKE transaction.
+/// success case: retrieve correct INVOKE transaction.
+/// 
 #[rstest]
 #[tokio::test]
 async fn work_transaction_invoke(clients: HashMap<String, JsonRpcClient<HttpTransport>>) {
@@ -43,6 +55,12 @@ async fn work_transaction_invoke(clients: HashMap<String, JsonRpcClient<HttpTran
     assert_eq!(response_deoxys, response_pathfinder);
 }
 
+///
+/// Unit test for `starknet_getTransactionByHash`
+/// 
+/// purpose: call getTransactionHash on L1_HANDLER transaction.
+/// success case: retrieve correct INVOKE transaction.
+/// 
 #[rstest]
 #[tokio::test]
 async fn work_transaction_l1_handler(clients: HashMap<String, JsonRpcClient<HttpTransport>>) {
@@ -61,6 +79,14 @@ async fn work_transaction_l1_handler(clients: HashMap<String, JsonRpcClient<Http
     assert_eq!(response_deoxys, response_pathfinder);
 }
 
+// TODO: add tests for DEPLOY transaction
+
+///
+/// Unit test for `starknet_getTransactionByHash`
+/// 
+/// purpose: call getTransactionHash on DEPLOY_ACCOUNT transaction.
+/// success case: retrieve correct DEPLOY_ACCOUNT transaction.
+/// 
 #[rstest]
 #[tokio::test]
 async fn work_transaction_deploy_account(clients: HashMap<String, JsonRpcClient<HttpTransport>>) {

--- a/unit_tests/tests/test_get_transaction_by_hash.rs
+++ b/unit_tests/tests/test_get_transaction_by_hash.rs
@@ -4,7 +4,7 @@ mod common;
 use std::{collections::HashMap, assert_matches::assert_matches};
 
 use common::*;
-use starknet_core::types::{FieldElement, StarknetError};
+use starknet_core::types::{FieldElement, StarknetError, Transaction};
 use starknet_providers::{JsonRpcClient, jsonrpc::HttpTransport, Provider, StarknetErrorWithMessage, ProviderError, MaybeUnknownErrorCode};
 
 #[rstest]
@@ -23,4 +23,22 @@ async fn fail_non_existing_transaction(clients: HashMap<String, JsonRpcClient<Ht
             code: MaybeUnknownErrorCode::Known(StarknetError::TransactionHashNotFound)
         }
     )));
+}
+
+#[rstest]
+#[tokio::test]
+async fn work_transaction_invoke(clients: HashMap<String, JsonRpcClient<HttpTransport>>) {
+    let deoxys = &clients[DEOXYS];
+    let pathfinder = &clients[PATHFINDER];
+
+    let response_deoxys = deoxys.get_transaction_by_hash(
+        FieldElement::from_hex_be(TRANSACTION_INVOKE).unwrap()
+    ).await.expect("Error waiting for response from Deoxys node");
+
+    let response_pathfinder = pathfinder.get_transaction_by_hash(
+        FieldElement::from_hex_be(TRANSACTION_INVOKE).unwrap()
+    ).await.expect("Error waiting for response from Pathfinder node");
+
+    assert_matches!(response_deoxys, Transaction::Invoke(_));
+    assert_eq!(response_deoxys, response_pathfinder);
 }

--- a/unit_tests/tests/test_get_transaction_by_hash.rs
+++ b/unit_tests/tests/test_get_transaction_by_hash.rs
@@ -1,0 +1,26 @@
+#![feature(assert_matches)]
+
+mod common;
+use std::{collections::HashMap, assert_matches::assert_matches};
+
+use common::*;
+use starknet_core::types::{FieldElement, StarknetError};
+use starknet_providers::{JsonRpcClient, jsonrpc::HttpTransport, Provider, StarknetErrorWithMessage, ProviderError, MaybeUnknownErrorCode};
+
+#[rstest]
+#[tokio::test]
+async fn fail_non_existing_transaction(clients: HashMap<String, JsonRpcClient<HttpTransport>>) {
+    let deoxys = &clients[DEOXYS];
+
+    let response_deoxys = deoxys.get_transaction_by_hash(
+        FieldElement::ZERO
+    ).await.err();
+    
+    assert_matches!(
+        response_deoxys, 
+        Some(ProviderError::StarknetError(StarknetErrorWithMessage {
+            message: _,
+            code: MaybeUnknownErrorCode::Known(StarknetError::TransactionHashNotFound)
+        }
+    )));
+}

--- a/unit_tests/tests/test_get_transaction_by_hash.rs
+++ b/unit_tests/tests/test_get_transaction_by_hash.rs
@@ -42,3 +42,21 @@ async fn work_transaction_invoke(clients: HashMap<String, JsonRpcClient<HttpTran
     assert_matches!(response_deoxys, Transaction::Invoke(_));
     assert_eq!(response_deoxys, response_pathfinder);
 }
+
+#[rstest]
+#[tokio::test]
+async fn work_transaction_l1_handler(clients: HashMap<String, JsonRpcClient<HttpTransport>>) {
+    let deoxys = &clients[DEOXYS];
+    let pathfinder = &clients[PATHFINDER];
+
+    let response_deoxys = deoxys.get_transaction_by_hash(
+        FieldElement::from_hex_be(TRANSACTION_L1_HANDLER).unwrap()
+    ).await.expect("Error waiting for response from Deoxys node");
+
+    let response_pathfinder = pathfinder.get_transaction_by_hash(
+        FieldElement::from_hex_be(TRANSACTION_L1_HANDLER).unwrap()
+    ).await.expect("Error waiting for response from Pathfinder node");
+
+    assert_matches!(response_deoxys, Transaction::L1Handler(_));
+    assert_eq!(response_deoxys, response_pathfinder);
+}

--- a/unit_tests/tests/test_get_transaction_by_hash.rs
+++ b/unit_tests/tests/test_get_transaction_by_hash.rs
@@ -60,3 +60,21 @@ async fn work_transaction_l1_handler(clients: HashMap<String, JsonRpcClient<Http
     assert_matches!(response_deoxys, Transaction::L1Handler(_));
     assert_eq!(response_deoxys, response_pathfinder);
 }
+
+#[rstest]
+#[tokio::test]
+async fn work_transaction_deploy_account(clients: HashMap<String, JsonRpcClient<HttpTransport>>) {
+    let deoxys = &clients[DEOXYS];
+    let pathfinder = &clients[PATHFINDER];
+
+    let response_deoxys = deoxys.get_transaction_by_hash(
+        FieldElement::from_hex_be(TRANSACTION_DEPLOY_ACCOUNT).unwrap()
+    ).await.expect("Error waiting for response from Deoxys node");
+
+    let response_pathfinder = pathfinder.get_transaction_by_hash(
+        FieldElement::from_hex_be(TRANSACTION_DEPLOY_ACCOUNT).unwrap()
+    ).await.expect("Error waiting for response from Pathfinder node");
+
+    assert_matches!(response_deoxys, Transaction::DeployAccount(_));
+    assert_eq!(response_deoxys, response_pathfinder);
+}


### PR DESCRIPTION
:+1: Tests include the following:

- **non-existent transaction**: client error.
- **call on** `INVOKE` **transaction**: client should receive correct `INVOKE` transaction.
- **call on** `L1_HANDLER` **transaction**: client should receive correct `L1_HANDLER` transaction.
- **call on** `DEPLOY_ACCOUNT` **transaction**: client should receive correct `DEPLOY_ACCOUNT` transaction.