### PR TITLE
:white_check_mark: tested `starknet_getTransactionByBlockIdAndIndex`

### DIFF
--- a/unit_tests/src/constants.rs
+++ b/unit_tests/src/constants.rs
@@ -71,6 +71,49 @@ pub const CONTRACT_ACCOUNT_PROXY: &str = "0x05d7f4d55795b56ceb4dd93febe17954c7cf
 pub const CONTRACT_LEGACY: &str = "0x07076931c19d0ef52b847f9412c90a2ef999ff028f1005d2d069343061762fb7";
 pub const BLOCK_LEGACY: u64 = 2891;
 
+///
+/// INVOKE transaction accepted on L1, also transaction 1 at block 5000
+/// 
+/// Details concerning this transaction can be found on [StarkScan](https://starkscan.co/tx/0x0214840bad3099f95c40106097b8ef5fd16f06cb23efcdaec297398f77174597)
+/// 
+pub const TRANSACTION_INVOKE: &str = "0x0214840bad3099f95c40106097b8ef5fd16f06cb23efcdaec297398f77174597";
+pub const TRANSACTION_INVOKE_INDEX: u64 = 1;
+pub const TRANSACTION_INVOKE_BLOCK_NB: u64 = 50000;
+
+///
+/// L1_HANDLER transaction accepted on L1, also transaction 57 at block 50000
+/// 
+/// Details concerning this transaction can be found on [StarkScan](https://starkscan.co/tx/0x05ca6470c37e943b0ae172a11359f7a457054319e8ae8771af32a1f397c7c208)
+/// 
+pub const TRANSACTION_L1_HANDLER: &str = "0x05ca6470c37e943b0ae172a11359f7a457054319e8ae8771af32a1f397c7c208";
+pub const TRANSACTION_L1_HANDLER_INDEX: u64 = 57;
+pub const TRANSACTION_L1_HANDLER_BLOCK_NB: u64 = 50000;
+
+///
+/// DECLARE transaction accepted on L1, also transaction 44 at block 49990
+/// 
+/// Details concerning this transaction can be found on [StarkScan](https://starkscan.co/tx/0x056c0723ef6cde62f589bbf7c5c40897b6e3d9c13e960c5e7f28276d8e9c3229)
+/// 
+pub const TRANSACTION_DECLARE: &str = "0x056c0723ef6cde62f589bbf7c5c40897b6e3d9c13e960c5e7f28276d8e9c3229";
+pub const TRANSACTION_DECLARE_INDEX: u64 = 44;
+pub const TRANSACTION_DECLARE_BLOCK_NB: u64 = 49990;
+
+///
+/// DEPLOY_ACCOUNT transaction accepted on L1, also transaction 0 at block 5000
+/// 
+/// Details concerning this transaction can be found on [StarkScan](https://starkscan.co/tx/0x0604e143591a6bff980f3141abdfc87f1ef3243785d251367cdaa7da5c337ba4)
+/// 
+pub const TRANSACTION_DEPLOY_ACCOUNT: &str = "0x0604e143591a6bff980f3141abdfc87f1ef3243785d251367cdaa7da5c337ba4";
+pub const TRANSACTION_DEPLOY_ACCOUNT_INDEX: u64 = 0;
+pub const TRANSACTION_DEPLOY_ACCOUNT_BLOCK_NB: u64 = 50000;
+
+///
+/// Random reverted Starknet transaction
+/// 
+/// Details concerning this transaction can be found on [StarkScan](https://starkscan.co/tx/0x016ed559467c50c12f225f348ca8895d54b91a499ad6f856cb6086e317c120ca)
+/// 
+pub const TRANSACTION_REVERTED: &str = "0x016ed559467c50c12f225f348ca8895d54b91a499ad6f856cb6086e317c120ca";
+
 pub const ACCOUNT_CONTRACT: &str = "";
 pub const TEST_CONTRACT_ADDRESS: &str = "";
 pub const CAIRO_1_ACCOUNT_CONTRACT_CLASS_HASH: &str = "";

--- a/unit_tests/tests/test_get_transaction_by_block_id_and_index.rs
+++ b/unit_tests/tests/test_get_transaction_by_block_id_and_index.rs
@@ -10,6 +10,38 @@ use starknet_providers::{JsonRpcClient, jsonrpc::HttpTransport, Provider};
 ///
 /// Unit test for `starknet_getTransactionByBlockIdAndIndex`
 /// 
+/// purpose: get INVOKE transaction.
+/// success case: client retrieves same transaction with getTransactionByBlockIdAndIndex and getTransactionByHash.
+/// 
+#[rstest]
+#[tokio::test]
+async fn work_deploy_invoke(clients: HashMap<String, JsonRpcClient<HttpTransport>>) {
+    let deoxys = &clients[DEOXYS];
+    let pathfinder = &clients[PATHFINDER];
+
+    // getting transaction through block number and index
+    let response_deoxys = deoxys.get_transaction_by_block_id_and_index(
+        BlockId::Number(TRANSACTION_INVOKE_BLOCK_NB),
+        TRANSACTION_INVOKE_INDEX
+    ).await.expect("Error waiting for response from Deoxys node");
+
+    let response_pathfinder = pathfinder.get_transaction_by_block_id_and_index(
+        BlockId::Number(TRANSACTION_INVOKE_BLOCK_NB),
+        TRANSACTION_INVOKE_INDEX
+    ).await.expect("Error waiting for response from Pathfinder node");
+
+    // getting transaction through hash
+    let response_expected = deoxys.get_transaction_by_hash(
+        FieldElement::from_hex_be(TRANSACTION_INVOKE).unwrap()
+    ).await.expect("Error waiting for response from Deoxys node");
+
+    assert_eq!(response_deoxys, response_expected);
+    assert_eq!(response_deoxys, response_pathfinder);
+}
+
+///
+/// Unit test for `starknet_getTransactionByBlockIdAndIndex`
+/// 
 /// purpose: get DEPLOY_ACCOUNT transaction.
 /// success case: client retrieves same transaction with getTransactionByBlockIdAndIndex and getTransactionByHash.
 /// 

--- a/unit_tests/tests/test_get_transaction_by_block_id_and_index.rs
+++ b/unit_tests/tests/test_get_transaction_by_block_id_and_index.rs
@@ -1,0 +1,40 @@
+#![feature(assert_matches)]
+
+mod common;
+use std::collections::HashMap;
+
+use common::*;
+use starknet_core::types::{FieldElement, BlockId};
+use starknet_providers::{JsonRpcClient, jsonrpc::HttpTransport, Provider};
+
+///
+/// Unit test for `starknet_getTransactionByBlockIdAndIndex`
+/// 
+/// purpose: get DEPLOY_ACCOUNT transaction.
+/// success case: client retrieves same transaction with getTransactionByBlockIdAndIndex and getTransactionByHash.
+/// 
+#[rstest]
+#[tokio::test]
+async fn work_deploy_account(clients: HashMap<String, JsonRpcClient<HttpTransport>>) {
+    let deoxys = &clients[DEOXYS];
+    let pathfinder = &clients[PATHFINDER];
+
+    // getting transaction through block number and index
+    let response_deoxys = deoxys.get_transaction_by_block_id_and_index(
+        BlockId::Number(TRANSACTION_DEPLOY_ACCOUNT_BLOCK_NB),
+        TRANSACTION_DEPLOY_ACCOUNT_INDEX
+    ).await.expect("Error waiting for response from Deoxys node");
+
+    let response_pathfinder = pathfinder.get_transaction_by_block_id_and_index(
+        BlockId::Number(TRANSACTION_DEPLOY_ACCOUNT_BLOCK_NB),
+        TRANSACTION_DEPLOY_ACCOUNT_INDEX
+    ).await.expect("Error waiting for response from Pathfinder node");
+
+    // getting transaction through hash
+    let response_expected = deoxys.get_transaction_by_hash(
+        FieldElement::from_hex_be(TRANSACTION_DEPLOY_ACCOUNT).unwrap()
+    ).await.expect("Error waiting for response from Deoxys node");
+
+    assert_eq!(response_deoxys, response_expected);
+    assert_eq!(response_deoxys, response_pathfinder);
+}

--- a/unit_tests/tests/test_get_transaction_by_block_id_and_index.rs
+++ b/unit_tests/tests/test_get_transaction_by_block_id_and_index.rs
@@ -42,6 +42,38 @@ async fn work_deploy_invoke(clients: HashMap<String, JsonRpcClient<HttpTransport
 ///
 /// Unit test for `starknet_getTransactionByBlockIdAndIndex`
 /// 
+/// purpose: get L1_HANDLER transaction.
+/// success case: client retrieves same transaction with getTransactionByBlockIdAndIndex and getTransactionByHash.
+/// 
+#[rstest]
+#[tokio::test]
+async fn work_deploy_l1_handler(clients: HashMap<String, JsonRpcClient<HttpTransport>>) {
+    let deoxys = &clients[DEOXYS];
+    let pathfinder = &clients[PATHFINDER];
+
+    // getting transaction through block number and index
+    let response_deoxys = deoxys.get_transaction_by_block_id_and_index(
+        BlockId::Number(TRANSACTION_L1_HANDLER_BLOCK_NB),
+        TRANSACTION_L1_HANDLER_INDEX
+    ).await.expect("Error waiting for response from Deoxys node");
+
+    let response_pathfinder = pathfinder.get_transaction_by_block_id_and_index(
+        BlockId::Number(TRANSACTION_L1_HANDLER_BLOCK_NB),
+        TRANSACTION_L1_HANDLER_INDEX
+    ).await.expect("Error waiting for response from Pathfinder node");
+
+    // getting transaction through hash
+    let response_expected = deoxys.get_transaction_by_hash(
+        FieldElement::from_hex_be(TRANSACTION_L1_HANDLER).unwrap()
+    ).await.expect("Error waiting for response from Deoxys node");
+
+    assert_eq!(response_deoxys, response_expected);
+    assert_eq!(response_deoxys, response_pathfinder);
+}
+
+///
+/// Unit test for `starknet_getTransactionByBlockIdAndIndex`
+/// 
 /// purpose: get DEPLOY_ACCOUNT transaction.
 /// success case: client retrieves same transaction with getTransactionByBlockIdAndIndex and getTransactionByHash.
 /// 

--- a/unit_tests/tests/test_get_transaction_by_block_id_and_index.rs
+++ b/unit_tests/tests/test_get_transaction_by_block_id_and_index.rs
@@ -74,6 +74,38 @@ async fn work_deploy_l1_handler(clients: HashMap<String, JsonRpcClient<HttpTrans
 ///
 /// Unit test for `starknet_getTransactionByBlockIdAndIndex`
 /// 
+/// purpose: get DECLARE transaction.
+/// success case: client retrieves same transaction with getTransactionByBlockIdAndIndex and getTransactionByHash.
+/// 
+#[rstest]
+#[tokio::test]
+async fn work_deploy_declare(clients: HashMap<String, JsonRpcClient<HttpTransport>>) {
+    let deoxys = &clients[DEOXYS];
+    let pathfinder = &clients[PATHFINDER];
+
+    // getting transaction through block number and index
+    let response_deoxys = deoxys.get_transaction_by_block_id_and_index(
+        BlockId::Number(TRANSACTION_DECLARE_BLOCK_NB),
+        TRANSACTION_DECLARE_INDEX
+    ).await.expect("Error waiting for response from Deoxys node");
+
+    let response_pathfinder = pathfinder.get_transaction_by_block_id_and_index(
+        BlockId::Number(TRANSACTION_DECLARE_BLOCK_NB),
+        TRANSACTION_DECLARE_INDEX
+    ).await.expect("Error waiting for response from Pathfinder node");
+
+    // getting transaction through hash
+    let response_expected = deoxys.get_transaction_by_hash(
+        FieldElement::from_hex_be(TRANSACTION_DECLARE).unwrap()
+    ).await.expect("Error waiting for response from Deoxys node");
+
+    assert_eq!(response_deoxys, response_expected);
+    assert_eq!(response_deoxys, response_pathfinder);
+}
+
+///
+/// Unit test for `starknet_getTransactionByBlockIdAndIndex`
+/// 
 /// purpose: get DEPLOY_ACCOUNT transaction.
 /// success case: client retrieves same transaction with getTransactionByBlockIdAndIndex and getTransactionByHash.
 /// 

--- a/unit_tests/tests/test_get_transaction_by_block_id_and_index.rs
+++ b/unit_tests/tests/test_get_transaction_by_block_id_and_index.rs
@@ -32,6 +32,30 @@ async fn fail_non_existent_block(clients: HashMap<String, JsonRpcClient<HttpTran
     );
 }
 
+///
+/// Unit test for `starknet_getTransactionByBlockIdAndIndex`
+/// 
+/// purpose: call on valid block with out-of-range index.
+/// fail case: index out of block range (block 5000 only has 389 transactions)
+/// 
+#[rstest]
+#[tokio::test]
+async fn fail_non_existent_block_index(clients: HashMap<String, JsonRpcClient<HttpTransport>>) {
+    let deoxys = &clients[DEOXYS];
+
+    let response_deoxys = deoxys.get_transaction_by_block_id_and_index(
+        BlockId::Number(5000),
+        389
+    ).await.err();
+
+    assert_matches!(
+        response_deoxys,
+        Some(ProviderError::StarknetError(StarknetErrorWithMessage {
+            message: _,
+            code: MaybeUnknownErrorCode::Known(StarknetError::InvalidTransactionIndex)
+        }))
+    );
+}
 
 ///
 /// Unit test for `starknet_getTransactionByBlockIdAndIndex`


### PR DESCRIPTION
:+1: Tests include the following:

- **non-existent block**: client error.
- **block index out of range**: client error.
- **call on** `INVOKE` **transaction**: client should receive correct `INVOKE` transaction.
- **call on** `L1_HANDLER` **transaction**: client should receive correct `L1_HANDLER` transaction.
- **call on** `DECLARE` **transaction**: client should receive correct `DECLARE` transaction.
- **call on** `DEPLOY_ACCOUNT` **transaction**: client should receive correct `DEPLOY_ACCOUNT` transaction.