### PR TITLE
add test on get_block_transaction count and get_block_with_txs

### DIFF
--- a/unit_tests/tests/test_get_block_transaction_count.rs
+++ b/unit_tests/tests/test_get_block_transaction_count.rs
@@ -1,0 +1,153 @@
+#![feature(assert_matches)]
+
+/// TODO test on a block withouth transactions
+
+mod common;
+use common::*;
+
+use std::{assert_matches::assert_matches, collections::HashMap};
+
+use starknet_core::types::{BlockId, BlockTag, FieldElement, StarknetError};
+use starknet_providers::{
+    jsonrpc::{HttpTransport, JsonRpcClient},
+    MaybeUnknownErrorCode, Provider, ProviderError, StarknetErrorWithMessage,
+};
+use unit_tests::constants::DEOXYS;
+
+#[rstest]
+#[tokio::test]
+async fn fail_non_existing_block(clients: HashMap<String, JsonRpcClient<HttpTransport>>) {
+    let deoxys = &clients[DEOXYS];
+
+    let response_deoxys = deoxys
+        .get_block_transaction_count(BlockId::Hash(FieldElement::ZERO))
+        .await
+        .err();
+
+    assert_matches!(
+        response_deoxys,
+        Some(ProviderError::StarknetError(StarknetErrorWithMessage {
+            message: _,
+            code: MaybeUnknownErrorCode::Known(StarknetError::BlockNotFound)
+        }))
+    );
+}
+
+#[rstest]
+#[tokio::test]
+async fn work_with_latest_block(clients: HashMap<String, JsonRpcClient<HttpTransport>>) {
+    let deoxys = &clients[DEOXYS];
+    let pathfinder = &clients[PATHFINDER];
+
+    let block_tag = BlockId::Tag(BlockTag::Latest);
+
+    let response_deoxys = deoxys
+        .get_block_transaction_count(block_tag)
+        .await
+        .expect("Error waiting for response from Deoxys node");
+
+    let response_pathfinder = pathfinder
+        .get_block_transaction_count(block_tag)
+        .await
+        .expect("Error waiting for response from Pathfinder node");
+
+    assert_eq!(response_deoxys, response_pathfinder);
+}
+
+#[rstest]
+#[tokio::test]
+async fn work_with_block_one_num(clients: HashMap<String, JsonRpcClient<HttpTransport>>) {
+    let deoxys = &clients[DEOXYS];
+    let pathfinder = &clients[PATHFINDER];
+
+    let block_number = BlockId::Number(1);
+
+    let response_deoxys = deoxys
+        .get_block_transaction_count(block_number)
+        .await
+        .expect("Error waiting for response from Deoxys node");
+
+    let response_pathfinder = pathfinder
+        .get_block_transaction_count(block_number)
+        .await
+        .expect("Error waiting for response from Pathfinder node");
+
+    assert_eq!(response_deoxys, response_pathfinder);
+}
+
+#[rstest]
+#[tokio::test]
+async fn work_with_block_one_hash(clients: HashMap<String, JsonRpcClient<HttpTransport>>) {
+    let deoxys = &clients[DEOXYS];
+    let pathfinder = &clients[PATHFINDER];
+
+    let block_hash = BlockId::Hash(
+        FieldElement::from_hex_be(
+            "0x2a70fb03fe363a2d6be843343a1d81ce6abeda1e9bd5cc6ad8fa9f45e30fdeb",
+        )
+        .expect("Error parsing block hash"),
+    );
+
+    let response_deoxys = deoxys
+        .get_block_transaction_count(block_hash)
+        .await
+        .expect("Error waiting for response from Deoxys node");
+
+    let response_pathfinder = pathfinder
+        .get_block_transaction_count(block_hash)
+        .await
+        .expect("Error waiting for response from Pathfinder node");
+
+    assert_eq!(response_deoxys, response_pathfinder);
+}
+
+#[rstest]
+#[tokio::test]
+async fn work_with_block_one_hundred_thousand_num(
+    clients: HashMap<String, JsonRpcClient<HttpTransport>>,
+) {
+    let deoxys = &clients[DEOXYS];
+    let pathfinder = &clients[PATHFINDER];
+
+    let block_number = BlockId::Number(100000);
+
+    let response_deoxys = deoxys
+        .get_block_transaction_count(block_number)
+        .await
+        .expect("Error waiting for response from Deoxys node");
+
+    let response_pathfinder = pathfinder
+        .get_block_transaction_count(block_number)
+        .await
+        .expect("Error waiting for response from Pathfinder node");
+
+    assert_eq!(response_deoxys, response_pathfinder);
+}
+
+#[rstest]
+#[tokio::test]
+async fn work_with_block_one_hundred_thousand_hash(
+    clients: HashMap<String, JsonRpcClient<HttpTransport>>,
+) {
+    let deoxys = &clients[DEOXYS];
+    let pathfinder = &clients[PATHFINDER];
+
+    let block_hash = BlockId::Hash(
+        FieldElement::from_hex_be(
+            "0x4f45f870c79f7656c5d7c3c2c28ca0c2fe7206f22f56ac2183f81de521ab340",
+        )
+        .expect("Error parsing block hash"),
+    );
+
+    let response_deoxys = deoxys
+        .get_block_transaction_count(block_hash)
+        .await
+        .expect("Error waiting for response from Deoxys node");
+
+    let response_pathfinder = pathfinder
+        .get_block_transaction_count(block_hash)
+        .await
+        .expect("Error waiting for response from Pathfinder node");
+
+    assert_eq!(response_deoxys, response_pathfinder);
+}

--- a/unit_tests/tests/test_get_block_with_txs.rs
+++ b/unit_tests/tests/test_get_block_with_txs.rs
@@ -1,0 +1,152 @@
+#![feature(assert_matches)]
+
+/// TODO test on a block withouth transactions
+mod common;
+use common::*;
+
+use std::{assert_matches::assert_matches, collections::HashMap};
+
+use starknet_core::types::{BlockId, BlockTag, FieldElement, StarknetError};
+use starknet_providers::{
+    jsonrpc::{HttpTransport, JsonRpcClient},
+    MaybeUnknownErrorCode, Provider, ProviderError, StarknetErrorWithMessage,
+};
+use unit_tests::constants::DEOXYS;
+
+#[rstest]
+#[tokio::test]
+async fn fail_non_existing_block(clients: HashMap<String, JsonRpcClient<HttpTransport>>) {
+    let deoxys = &clients[DEOXYS];
+
+    let response_deoxys = deoxys
+        .get_block_with_txs(BlockId::Hash(FieldElement::ZERO))
+        .await
+        .err();
+
+    assert_matches!(
+        response_deoxys,
+        Some(ProviderError::StarknetError(StarknetErrorWithMessage {
+            message: _,
+            code: MaybeUnknownErrorCode::Known(StarknetError::BlockNotFound)
+        }))
+    );
+}
+
+#[rstest]
+#[tokio::test]
+async fn work_with_latest_block(clients: HashMap<String, JsonRpcClient<HttpTransport>>) {
+    let deoxys = &clients[DEOXYS];
+    let pathfinder = &clients[PATHFINDER];
+
+    let block_tag = BlockId::Tag(BlockTag::Latest);
+
+    let response_deoxys = deoxys
+        .get_block_with_txs(block_tag)
+        .await
+        .expect("Error waiting for response from Deoxys node");
+
+    let response_pathfinder = pathfinder
+        .get_block_with_txs(block_tag)
+        .await
+        .expect("Error waiting for response from Pathfinder node");
+
+    assert_eq!(response_deoxys, response_pathfinder);
+}
+
+#[rstest]
+#[tokio::test]
+async fn work_with_block_one_num(clients: HashMap<String, JsonRpcClient<HttpTransport>>) {
+    let deoxys = &clients[DEOXYS];
+    let pathfinder = &clients[PATHFINDER];
+
+    let block_number = BlockId::Number(1);
+
+    let response_deoxys = deoxys
+        .get_block_with_txs(block_number)
+        .await
+        .expect("Error waiting for response from Deoxys node");
+
+    let response_pathfinder = pathfinder
+        .get_block_with_txs(block_number)
+        .await
+        .expect("Error waiting for response from Pathfinder node");
+
+    assert_eq!(response_deoxys, response_pathfinder);
+}
+
+#[rstest]
+#[tokio::test]
+async fn work_with_block_one_hash(clients: HashMap<String, JsonRpcClient<HttpTransport>>) {
+    let deoxys = &clients[DEOXYS];
+    let pathfinder = &clients[PATHFINDER];
+
+    let block_hash = BlockId::Hash(
+        FieldElement::from_hex_be(
+            "0x2a70fb03fe363a2d6be843343a1d81ce6abeda1e9bd5cc6ad8fa9f45e30fdeb",
+        )
+        .expect("Error parsing block hash"),
+    );
+
+    let response_deoxys = deoxys
+        .get_block_with_txs(block_hash)
+        .await
+        .expect("Error waiting for response from Deoxys node");
+
+    let response_pathfinder = pathfinder
+        .get_block_with_txs(block_hash)
+        .await
+        .expect("Error waiting for response from Pathfinder node");
+
+    assert_eq!(response_deoxys, response_pathfinder);
+}
+
+#[rstest]
+#[tokio::test]
+async fn work_with_block_one_hundred_thousand_num(
+    clients: HashMap<String, JsonRpcClient<HttpTransport>>,
+) {
+    let deoxys = &clients[DEOXYS];
+    let pathfinder = &clients[PATHFINDER];
+
+    let block_number = BlockId::Number(100000);
+
+    let response_deoxys = deoxys
+        .get_block_with_txs(block_number)
+        .await
+        .expect("Error waiting for response from Deoxys node");
+
+    let response_pathfinder = pathfinder
+        .get_block_with_txs(block_number)
+        .await
+        .expect("Error waiting for response from Pathfinder node");
+
+    assert_eq!(response_deoxys, response_pathfinder);
+}
+
+#[rstest]
+#[tokio::test]
+async fn work_with_block_one_hundred_thousand_hash(
+    clients: HashMap<String, JsonRpcClient<HttpTransport>>,
+) {
+    let deoxys = &clients[DEOXYS];
+    let pathfinder = &clients[PATHFINDER];
+
+    let block_hash = BlockId::Hash(
+        FieldElement::from_hex_be(
+            "0x4f45f870c79f7656c5d7c3c2c28ca0c2fe7206f22f56ac2183f81de521ab340",
+        )
+        .expect("Error parsing block hash"),
+    );
+
+    let response_deoxys = deoxys
+        .get_block_with_txs(block_hash)
+        .await
+        .expect("Error waiting for response from Deoxys node");
+
+    let response_pathfinder = pathfinder
+        .get_block_with_txs(block_hash)
+        .await
+        .expect("Error waiting for response from Pathfinder node");
+
+    assert_eq!(response_deoxys, response_pathfinder);
+}


### PR DESCRIPTION
## test includes : 
- test on block 1 with block_number as a parameter
- test on block 1 with block_hash as a parameter
- test on block 100000 with block_number as a parameter
- test on block 100000 with block_hash as a parameter
- test on pending block
- test on non existing block

## it will remain :
- test on a block without transaction