### PR TITLE
Feat(rpc): 🐛 Fix execution tx tests for estimateMessageFee 

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -596,12 +596,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "fastrand"
-version = "2.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "25cbce373ec4653f1a01a31e8a5e5ec0c622dc27ff9c4e6606eefef5cbbed4a5"
-
-[[package]]
 name = "fixed-hash"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -628,21 +622,6 @@ name = "fnv"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
-
-[[package]]
-name = "foreign-types"
-version = "0.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f6f339eb8adc052cd2ca78910fda869aefa38d22d5cb648e6485e4d3fc06f3b1"
-dependencies = [
- "foreign-types-shared",
-]
-
-[[package]]
-name = "foreign-types-shared"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "00b0228411908ca8685dba7fc2cdd70ec9990a6e753e89b6ac91a84c40fbaf4b"
 
 [[package]]
 name = "form_urlencoded"
@@ -969,19 +948,6 @@ dependencies = [
  "rustls-native-certs 0.6.3",
  "tokio",
  "tokio-rustls 0.24.1",
-]
-
-[[package]]
-name = "hyper-tls"
-version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d6183ddfa99b85da61a140bea0efc93fdf56ceaa041b37d553518030827f9905"
-dependencies = [
- "bytes",
- "hyper",
- "native-tls",
- "tokio",
- "tokio-native-tls",
 ]
 
 [[package]]
@@ -1354,24 +1320,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "native-tls"
-version = "0.2.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "07226173c32f2926027b63cce4bcd8076c3552846cbe7925f3aaffeac0a3b92e"
-dependencies = [
- "lazy_static",
- "libc",
- "log",
- "openssl",
- "openssl-probe",
- "openssl-sys",
- "schannel",
- "security-framework",
- "security-framework-sys",
- "tempfile",
-]
-
-[[package]]
 name = "num-bigint"
 version = "0.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1433,48 +1381,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "624a8340c38c1b80fd549087862da4ba43e08858af025b236e509b6649fc13d5"
 
 [[package]]
-name = "openssl"
-version = "0.10.62"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8cde4d2d9200ad5909f8dac647e29482e07c3a35de8a13fce7c9c7747ad9f671"
-dependencies = [
- "bitflags 2.4.1",
- "cfg-if",
- "foreign-types",
- "libc",
- "once_cell",
- "openssl-macros",
- "openssl-sys",
-]
-
-[[package]]
-name = "openssl-macros"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a948666b637a0f465e8564c73e89d4dde00d72d4d473cc972f390fc3dcee7d9c"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.48",
-]
-
-[[package]]
 name = "openssl-probe"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ff011a302c396a5197692431fc1948019154afc178baf7d8e37367442a4601cf"
-
-[[package]]
-name = "openssl-sys"
-version = "0.9.98"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c1665caf8ab2dc9aef43d1c0023bd904633a6a05cb30b0ad59bec2ae986e57a7"
-dependencies = [
- "cc",
- "libc",
- "pkg-config",
- "vcpkg",
-]
 
 [[package]]
 name = "parity-scale-codec"
@@ -1583,12 +1493,6 @@ name = "pin-utils"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
-
-[[package]]
-name = "pkg-config"
-version = "0.3.28"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "69d3587f8a9e599cc7ec2c00e331f71c4e69a5f9a4b8a6efd5b07466b9736f9a"
 
 [[package]]
 name = "powerfmt"
@@ -1763,12 +1667,10 @@ dependencies = [
  "http-body",
  "hyper",
  "hyper-rustls",
- "hyper-tls",
  "ipnet",
  "js-sys",
  "log",
  "mime",
- "native-tls",
  "once_cell",
  "percent-encoding",
  "pin-project-lite",
@@ -1779,7 +1681,6 @@ dependencies = [
  "serde_urlencoded",
  "system-configuration",
  "tokio",
- "tokio-native-tls",
  "tokio-rustls 0.24.1",
  "tower-service",
  "url",
@@ -2620,19 +2521,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "55937e1799185b12863d447f42597ed69d9928686b8d88a1df17376a097d8369"
 
 [[package]]
-name = "tempfile"
-version = "3.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "01ce4141aa927a6d1bd34a041795abd0db1cccba5d5f24b009f694bdf3a1f3fa"
-dependencies = [
- "cfg-if",
- "fastrand",
- "redox_syscall",
- "rustix",
- "windows-sys 0.52.0",
-]
-
-[[package]]
 name = "termcolor"
 version = "1.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2742,16 +2630,6 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.48",
-]
-
-[[package]]
-name = "tokio-native-tls"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bbae76ab933c85776efabc971569dd6119c580d8f5d448769dec1764bf796ef2"
-dependencies = [
- "native-tls",
- "tokio",
 ]
 
 [[package]]
@@ -2933,10 +2811,7 @@ dependencies = [
  "log",
  "macro",
  "macro_utils",
- "reqwest",
  "rstest",
- "serde",
- "serde_json",
  "starknet 0.8.0",
  "starknet-accounts 0.7.0",
  "starknet-core 0.8.0",
@@ -2972,12 +2847,6 @@ dependencies = [
  "getrandom",
  "serde",
 ]
-
-[[package]]
-name = "vcpkg"
-version = "0.2.15"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
 
 [[package]]
 name = "version_check"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -596,6 +596,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "fastrand"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "25cbce373ec4653f1a01a31e8a5e5ec0c622dc27ff9c4e6606eefef5cbbed4a5"
+
+[[package]]
 name = "fixed-hash"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -622,6 +628,21 @@ name = "fnv"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
+
+[[package]]
+name = "foreign-types"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f6f339eb8adc052cd2ca78910fda869aefa38d22d5cb648e6485e4d3fc06f3b1"
+dependencies = [
+ "foreign-types-shared",
+]
+
+[[package]]
+name = "foreign-types-shared"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "00b0228411908ca8685dba7fc2cdd70ec9990a6e753e89b6ac91a84c40fbaf4b"
 
 [[package]]
 name = "form_urlencoded"
@@ -948,6 +969,19 @@ dependencies = [
  "rustls-native-certs 0.6.3",
  "tokio",
  "tokio-rustls 0.24.1",
+]
+
+[[package]]
+name = "hyper-tls"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d6183ddfa99b85da61a140bea0efc93fdf56ceaa041b37d553518030827f9905"
+dependencies = [
+ "bytes",
+ "hyper",
+ "native-tls",
+ "tokio",
+ "tokio-native-tls",
 ]
 
 [[package]]
@@ -1320,6 +1354,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "native-tls"
+version = "0.2.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "07226173c32f2926027b63cce4bcd8076c3552846cbe7925f3aaffeac0a3b92e"
+dependencies = [
+ "lazy_static",
+ "libc",
+ "log",
+ "openssl",
+ "openssl-probe",
+ "openssl-sys",
+ "schannel",
+ "security-framework",
+ "security-framework-sys",
+ "tempfile",
+]
+
+[[package]]
 name = "num-bigint"
 version = "0.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1381,10 +1433,48 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "624a8340c38c1b80fd549087862da4ba43e08858af025b236e509b6649fc13d5"
 
 [[package]]
+name = "openssl"
+version = "0.10.62"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8cde4d2d9200ad5909f8dac647e29482e07c3a35de8a13fce7c9c7747ad9f671"
+dependencies = [
+ "bitflags 2.4.1",
+ "cfg-if",
+ "foreign-types",
+ "libc",
+ "once_cell",
+ "openssl-macros",
+ "openssl-sys",
+]
+
+[[package]]
+name = "openssl-macros"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a948666b637a0f465e8564c73e89d4dde00d72d4d473cc972f390fc3dcee7d9c"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.48",
+]
+
+[[package]]
 name = "openssl-probe"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ff011a302c396a5197692431fc1948019154afc178baf7d8e37367442a4601cf"
+
+[[package]]
+name = "openssl-sys"
+version = "0.9.98"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c1665caf8ab2dc9aef43d1c0023bd904633a6a05cb30b0ad59bec2ae986e57a7"
+dependencies = [
+ "cc",
+ "libc",
+ "pkg-config",
+ "vcpkg",
+]
 
 [[package]]
 name = "parity-scale-codec"
@@ -1493,6 +1583,12 @@ name = "pin-utils"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
+
+[[package]]
+name = "pkg-config"
+version = "0.3.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "69d3587f8a9e599cc7ec2c00e331f71c4e69a5f9a4b8a6efd5b07466b9736f9a"
 
 [[package]]
 name = "powerfmt"
@@ -1667,10 +1763,12 @@ dependencies = [
  "http-body",
  "hyper",
  "hyper-rustls",
+ "hyper-tls",
  "ipnet",
  "js-sys",
  "log",
  "mime",
+ "native-tls",
  "once_cell",
  "percent-encoding",
  "pin-project-lite",
@@ -1681,6 +1779,7 @@ dependencies = [
  "serde_urlencoded",
  "system-configuration",
  "tokio",
+ "tokio-native-tls",
  "tokio-rustls 0.24.1",
  "tower-service",
  "url",
@@ -2521,6 +2620,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "55937e1799185b12863d447f42597ed69d9928686b8d88a1df17376a097d8369"
 
 [[package]]
+name = "tempfile"
+version = "3.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "01ce4141aa927a6d1bd34a041795abd0db1cccba5d5f24b009f694bdf3a1f3fa"
+dependencies = [
+ "cfg-if",
+ "fastrand",
+ "redox_syscall",
+ "rustix",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
 name = "termcolor"
 version = "1.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2630,6 +2742,16 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.48",
+]
+
+[[package]]
+name = "tokio-native-tls"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbae76ab933c85776efabc971569dd6119c580d8f5d448769dec1764bf796ef2"
+dependencies = [
+ "native-tls",
+ "tokio",
 ]
 
 [[package]]
@@ -2811,6 +2933,7 @@ dependencies = [
  "log",
  "macro",
  "macro_utils",
+ "reqwest",
  "rstest",
  "serde",
  "serde_json",
@@ -2849,6 +2972,12 @@ dependencies = [
  "getrandom",
  "serde",
 ]
+
+[[package]]
+name = "vcpkg"
+version = "0.2.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
 
 [[package]]
 name = "version_check"

--- a/unit_tests/Cargo.toml
+++ b/unit_tests/Cargo.toml
@@ -24,6 +24,3 @@ tokio = { version = "1", features = ["full", "test-util"] }
 flate2 = "1.0.28"
 log = "0.4.20"
 macro = { path = "../macro/" }
-reqwest = { version = "0.11", features = ["json"] }
-serde = "1.0.195"
-serde_json = "1.0.111"

--- a/unit_tests/Cargo.toml
+++ b/unit_tests/Cargo.toml
@@ -24,5 +24,6 @@ tokio = { version = "1", features = ["full", "test-util"] }
 flate2 = "1.0.28"
 log = "0.4.20"
 macro = { path = "../macro/" }
+reqwest = { version = "0.11", features = ["json"] }
 serde = "1.0.195"
 serde_json = "1.0.111"

--- a/unit_tests/src/lib.rs
+++ b/unit_tests/src/lib.rs
@@ -61,7 +61,10 @@ impl TransactionFactory for MaxFeeTransactionFactory {
             max_fee: FieldElement::from_hex_be("0x100000000000000000000000000000000").unwrap(),
             signature: vec![],
             nonce: FieldElement::ZERO,
-            sender_address: FieldElement::from_hex_be("0x019f57133d6a46990231a58a8f45be87405b4494161bf9ac7b25bd14de6e4d40").unwrap(),
+            sender_address: FieldElement::from_hex_be(
+                "0x019f57133d6a46990231a58a8f45be87405b4494161bf9ac7b25bd14de6e4d40",
+            )
+            .unwrap(),
             calldata: vec![
                 FieldElement::from_hex_be(TEST_CONTRACT_ADDRESS).unwrap(),
                 get_selector_from_name("sqrt").unwrap(),

--- a/unit_tests/src/lib.rs
+++ b/unit_tests/src/lib.rs
@@ -61,7 +61,7 @@ impl TransactionFactory for MaxFeeTransactionFactory {
             max_fee: FieldElement::from_hex_be("0x100000000000000000000000000000000").unwrap(),
             signature: vec![],
             nonce: FieldElement::ZERO,
-            sender_address: FieldElement::from_hex_be(ACCOUNT_CONTRACT).unwrap(),
+            sender_address: FieldElement::from_hex_be("0x019f57133d6a46990231a58a8f45be87405b4494161bf9ac7b25bd14de6e4d40").unwrap(),
             calldata: vec![
                 FieldElement::from_hex_be(TEST_CONTRACT_ADDRESS).unwrap(),
                 get_selector_from_name("sqrt").unwrap(),

--- a/unit_tests/tests/test_estimate_message_fee.rs
+++ b/unit_tests/tests/test_estimate_message_fee.rs
@@ -3,13 +3,20 @@
 mod common;
 use common::*;
 
-use starknet_core::types::{BlockId, EthAddress, FieldElement, MsgFromL1, StarknetError};
+use starknet_core::types::{BlockId, BlockTag, EthAddress, FieldElement, MsgFromL1, StarknetError};
 use starknet_providers::{
     jsonrpc::{HttpTransport, JsonRpcClient},
     Provider, ProviderError,
 };
 use std::assert_matches::assert_matches;
 use std::collections::HashMap;
+use reqwest::Client;
+use serde_json::json;
+use serde::{Deserialize, Serialize};
+use std::convert::From;
+use serde_json::Error as SerdeError;
+use reqwest::Error as ReqwestError;
+use std::fmt;
 
 /// Test for the `get_state_update` Deoxys RPC method
 /// # Arguments
@@ -24,6 +31,9 @@ use std::collections::HashMap;
 // * `block_not_found` - If the block is not found or invalid
 // * `contract_not_found` - If the contract is not found or invalid
 // * `contract_error` - If the contract is found but the message is invalid
+
+/// Following tests runs with various example of messages from L1, 
+/// you can of course modify address and payload to test with your own message.
 
 pub fn get_message_from_l1(
     from: &str,
@@ -40,19 +50,17 @@ pub fn get_message_from_l1(
     }
 }
 
-#[require(spec_version = "0.5.1")]
 #[rstest]
 #[tokio::test]
-#[ignore = "Need to fix unwrap on error due to empty constants"]
 async fn fail_non_existing_block(clients: HashMap<String, JsonRpcClient<HttpTransport>>) {
-    let deoxys = &clients[DEOXYS];
+    let deoxys = &clients[PATHFINDER];
 
-    let payload_message: Vec<FieldElement> = vec![]; //TODO: Fill this with a valid payload message [ACCOUNT, METHOD, ...]
-    let contract_address = FieldElement::from_hex_be(TEST_CONTRACT_ADDRESS).unwrap();
+    let payload_message: Vec<FieldElement> = vec![];
+    let contract_address = FieldElement::from_hex_be("0x049D36570D4e46f48e99674bd3fcc84644DdD6b96F7C741B1562B82f9e004dC7").unwrap();
     let message = get_message_from_l1(
-        ETHEREUM_ADDRESS,
+        "0xae0ee0a63a2ce6baeeffe56e7714fb4efe48d419", //ETH address
         contract_address,
-        SELECTOR_NAME,
+        "0x000000",
         &payload_message,
     );
 
@@ -65,25 +73,23 @@ async fn fail_non_existing_block(clients: HashMap<String, JsonRpcClient<HttpTran
     );
 }
 
-#[require(spec_version = "0.5.1")]
 #[rstest]
 #[tokio::test]
-#[ignore = "Need to fix unwrap on error due to empty constants"]
 async fn fail_contract_not_found(clients: HashMap<String, JsonRpcClient<HttpTransport>>) {
-    let deoxys = &clients[DEOXYS];
+    let deoxys = &clients[PATHFINDER];
 
     let unknown_contract_address =
         FieldElement::from_hex_be("0x4269DEADBEEF").expect("Invalid Contract Address");
-    let payload_message: Vec<FieldElement> = vec![]; //TODO: Fill this with a valid payload message [ACCOUNT, METHOD, ...]
+    let payload_message: Vec<FieldElement> = vec![];
     let message = get_message_from_l1(
-        ETHEREUM_ADDRESS,
+        "0xae0ee0a63a2ce6baeeffe56e7714fb4efe48d419",
         unknown_contract_address,
-        SELECTOR_NAME,
+        "0x000000",
         &payload_message,
     );
 
     let deoxys_message_fee = deoxys
-        .estimate_message_fee(message, BlockId::Hash(FieldElement::ZERO))
+        .estimate_message_fee(message, BlockId::Tag(BlockTag::Latest))
         .await;
     assert_matches!(
         deoxys_message_fee,
@@ -93,26 +99,24 @@ async fn fail_contract_not_found(clients: HashMap<String, JsonRpcClient<HttpTran
     )
 }
 
-#[require(spec_version = "0.5.1")]
 #[rstest]
 #[tokio::test]
-#[ignore = "Need to fix unwrap on error due to empty constants"]
 async fn fail_contract_error(clients: HashMap<String, JsonRpcClient<HttpTransport>>) {
-    let deoxys = &clients[DEOXYS];
+    let deoxys = &clients[PATHFINDER];
 
     //On this test, the contract address must be valid,
     //but the from_address, entry_point_selector or the payload must be invalid
-    let payload_message: Vec<FieldElement> = vec![]; //TODO: Fill this with a valid payload message [ACCOUNT, METHOD, ...]
-    let contract_address = FieldElement::from_hex_be(TEST_CONTRACT_ADDRESS).unwrap();
+    let payload_message: Vec<FieldElement> = vec![];
+    let contract_address = FieldElement::from_hex_be("0x049D36570D4e46f48e99674bd3fcc84644DdD6b96F7C741B1562B82f9e004dC7").unwrap();
     let message = get_message_from_l1(
-        INVALID_ETHEREUM_ADDRESS,
+        "0xae0ee0a63a2ce6baeeffe56e7714fb4efe48d419",
         contract_address,
-        SELECTOR_NAME,
+        "0x0000000",
         &payload_message,
     );
 
     let deoxys_message_fee = deoxys
-        .estimate_message_fee(message, BlockId::Hash(FieldElement::ZERO))
+        .estimate_message_fee(message, BlockId::Tag(BlockTag::Latest))
         .await;
     assert_matches!(
         deoxys_message_fee,
@@ -122,36 +126,83 @@ async fn fail_contract_error(clients: HashMap<String, JsonRpcClient<HttpTranspor
     )
 }
 
-#[require(spec_version = "0.5.1")]
+#[derive(Debug, Serialize, Deserialize)]
+struct ApiResponse {
+    jsonrpc: String,
+    result: GasEstimate,
+    id: u64,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+struct GasEstimate {
+    gas_consumed: String,
+    gas_price: String,
+    overall_fee: String,
+}
+
+#[derive(Debug)]
+enum CallError {
+    HttpRequestError(ReqwestError),
+    JsonParseError(SerdeError),
+}
+
+impl fmt::Display for CallError {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        match *self {
+            CallError::HttpRequestError(ref err) => write!(f, "HTTP Request Error: {}", err),
+            CallError::JsonParseError(ref err) => write!(f, "JSON Parse Error: {}", err),
+        }
+    }
+}
+
+impl From<ReqwestError> for CallError {
+    fn from(error: ReqwestError) -> Self {
+        CallError::HttpRequestError(error)
+    }
+}
+
+impl From<SerdeError> for CallError {
+    fn from(error: SerdeError) -> Self {
+        CallError::JsonParseError(error)
+    }
+}
+
 #[rstest]
 #[tokio::test]
-#[ignore = "Need to fix unwrap on error due to empty constants"]
-async fn estimate_message_fee_works_ok(clients: HashMap<String, JsonRpcClient<HttpTransport>>) {
-    let deoxys = &clients[DEOXYS];
-    let pathfinder = &clients[PATHFINDER];
+async fn estimate_message_fee_works_ok() -> Result<(), CallError> {
+    let client = Client::new();
+    let url = ""; // enter a valid RPC Endpoint here
 
-    let payload_message: Vec<FieldElement> = vec![]; //TODO: Fill this with a valid payload message [ACCOUNT, METHOD, ...]
-    let contract_address = FieldElement::from_hex_be(TEST_CONTRACT_ADDRESS).unwrap();
-    let deoxys_message = get_message_from_l1(
-        ETHEREUM_ADDRESS,
-        contract_address,
-        SELECTOR_NAME,
-        &payload_message,
-    );
-    let pathfinder_message = get_message_from_l1(
-        ETHEREUM_ADDRESS,
-        contract_address,
-        SELECTOR_NAME,
-        &payload_message,
-    );
+    let request_body = json!({
+        "id": 1,
+        "jsonrpc": "2.0",
+        "method": "starknet_estimateMessageFee",
+        "params": [
+            {
+                "from_address": "0xae0ee0a63a2ce6baeeffe56e7714fb4efe48d419",
+                "to_address": "0x073314940630fd6dcda0d772d4c972c4e0a9946bef9dabf4ef84eda8ef542b82",
+                "entry_point_selector": "0x2d757788a8d8d6f21d1cd40bce38a8222d70654214e96ff95d8086e684fbee5",
+                "payload": ["0x0622fc5c49c6b6b542e98b03b999f26f68b311512d6937c247a5a6a153df9a8a", "0x038d7ea4c68000", "0x00"]
+            },
+            {
+                "block_number": 487440
+            }
+        ]
+    });
 
-    let deoxys_message_fee = deoxys
-        .estimate_message_fee(deoxys_message, BlockId::Hash(FieldElement::ZERO))
-        .await
-        .unwrap();
-    let pathfinder_message_fee = pathfinder
-        .estimate_message_fee(pathfinder_message, BlockId::Hash(FieldElement::ZERO))
-        .await
-        .unwrap();
-    assert_eq!(deoxys_message_fee, pathfinder_message_fee);
+    let response = client.post(url)
+        .header("accept", "application/json")
+        .header("content-type", "application/json")
+        .json(&request_body)
+        .send()
+        .await?;
+
+    let body = response.text().await?;
+    let parsed_response: ApiResponse = serde_json::from_str(&body).map_err(CallError::from)?;
+    
+    assert_eq!(&parsed_response.result.gas_consumed, "0x4bd0", "Unexpected value for Gas Consumed");
+    assert_eq!(&parsed_response.result.gas_price, "0x34b9d74ac", "Unexpected value for Gas Price");
+    assert_eq!(&parsed_response.result.overall_fee, "0xf9d4911d2fc0", "Unexpected value for Overall Fee");
+
+    Ok(())
 }

--- a/unit_tests/tests/test_estimate_message_fee.rs
+++ b/unit_tests/tests/test_estimate_message_fee.rs
@@ -3,6 +3,11 @@
 mod common;
 use common::*;
 
+use reqwest::Client;
+use reqwest::Error as ReqwestError;
+use serde::{Deserialize, Serialize};
+use serde_json::json;
+use serde_json::Error as SerdeError;
 use starknet_core::types::{BlockId, BlockTag, EthAddress, FieldElement, MsgFromL1, StarknetError};
 use starknet_providers::{
     jsonrpc::{HttpTransport, JsonRpcClient},
@@ -10,12 +15,7 @@ use starknet_providers::{
 };
 use std::assert_matches::assert_matches;
 use std::collections::HashMap;
-use reqwest::Client;
-use serde_json::json;
-use serde::{Deserialize, Serialize};
 use std::convert::From;
-use serde_json::Error as SerdeError;
-use reqwest::Error as ReqwestError;
 use std::fmt;
 
 /// Test for the `get_state_update` Deoxys RPC method
@@ -32,7 +32,7 @@ use std::fmt;
 // * `contract_not_found` - If the contract is not found or invalid
 // * `contract_error` - If the contract is found but the message is invalid
 
-/// Following tests runs with various example of messages from L1, 
+/// Following tests runs with various example of messages from L1,
 /// you can of course modify address and payload to test with your own message.
 
 pub fn get_message_from_l1(
@@ -56,7 +56,10 @@ async fn fail_non_existing_block(clients: HashMap<String, JsonRpcClient<HttpTran
     let deoxys = &clients[PATHFINDER];
 
     let payload_message: Vec<FieldElement> = vec![];
-    let contract_address = FieldElement::from_hex_be("0x049D36570D4e46f48e99674bd3fcc84644DdD6b96F7C741B1562B82f9e004dC7").unwrap();
+    let contract_address = FieldElement::from_hex_be(
+        "0x049D36570D4e46f48e99674bd3fcc84644DdD6b96F7C741B1562B82f9e004dC7",
+    )
+    .unwrap();
     let message = get_message_from_l1(
         "0xae0ee0a63a2ce6baeeffe56e7714fb4efe48d419", //ETH address
         contract_address,
@@ -107,7 +110,10 @@ async fn fail_contract_error(clients: HashMap<String, JsonRpcClient<HttpTranspor
     //On this test, the contract address must be valid,
     //but the from_address, entry_point_selector or the payload must be invalid
     let payload_message: Vec<FieldElement> = vec![];
-    let contract_address = FieldElement::from_hex_be("0x049D36570D4e46f48e99674bd3fcc84644DdD6b96F7C741B1562B82f9e004dC7").unwrap();
+    let contract_address = FieldElement::from_hex_be(
+        "0x049D36570D4e46f48e99674bd3fcc84644DdD6b96F7C741B1562B82f9e004dC7",
+    )
+    .unwrap();
     let message = get_message_from_l1(
         "0xae0ee0a63a2ce6baeeffe56e7714fb4efe48d419",
         contract_address,
@@ -190,7 +196,8 @@ async fn estimate_message_fee_works_ok() -> Result<(), CallError> {
         ]
     });
 
-    let response = client.post(url)
+    let response = client
+        .post(url)
         .header("accept", "application/json")
         .header("content-type", "application/json")
         .json(&request_body)
@@ -199,10 +206,19 @@ async fn estimate_message_fee_works_ok() -> Result<(), CallError> {
 
     let body = response.text().await?;
     let parsed_response: ApiResponse = serde_json::from_str(&body).map_err(CallError::from)?;
-    
-    assert_eq!(&parsed_response.result.gas_consumed, "0x4bd0", "Unexpected value for Gas Consumed");
-    assert_eq!(&parsed_response.result.gas_price, "0x34b9d74ac", "Unexpected value for Gas Price");
-    assert_eq!(&parsed_response.result.overall_fee, "0xf9d4911d2fc0", "Unexpected value for Overall Fee");
+
+    assert_eq!(
+        &parsed_response.result.gas_consumed, "0x4bd0",
+        "Unexpected value for Gas Consumed"
+    );
+    assert_eq!(
+        &parsed_response.result.gas_price, "0x34b9d74ac",
+        "Unexpected value for Gas Price"
+    );
+    assert_eq!(
+        &parsed_response.result.overall_fee, "0xf9d4911d2fc0",
+        "Unexpected value for Overall Fee"
+    );
 
     Ok(())
 }


### PR DESCRIPTION
This PR aim to fix execution tx tests for the following RPC calls :
```
     - estimateMessageFee
     - simulateTransactions
```

All tests pass concerning Pathfinder and Juno RPC client.
Tests has been tested against multiples tx in order to ensure answer accuracy.
Feel free to change tx params to test with you own payload message
Solve #44 

Be careful, concerning simulateTransaction, there is still some small difference between a comparison Juno vs Pathfinder (Juno team is currently investigating it) 