### PR TITLE
Feat: ✅ Adding tests for trace_transaction RPC call

### DIFF
--- a/unit_tests/tests/test_get_block_with_tx_hashes.rs
+++ b/unit_tests/tests/test_get_block_with_tx_hashes.rs
@@ -59,7 +59,7 @@ async fn work_existing_block(clients: HashMap<String, JsonRpcClient<HttpTranspor
     let deoxys = &clients[DEOXYS];
     let pathfinder = &clients[PATHFINDER];
 
-    let block_number = get_block_setting();
+    let block_number = BlockId::Number(193); //2243
 
     let response_deoxys = deoxys
         .get_block_with_tx_hashes(block_number)
@@ -163,7 +163,7 @@ async fn work_with_block_3800(
     work_with_block(deoxys, pathfinder, 3000).await;
 }
 
-/// block 50066 is one of the biggest blocks in the mainnet
+/// block 5066 is one of the biggest blocks in the mainnet
 #[rstest]
 #[tokio::test]
 async fn work_with_block_5066(

--- a/unit_tests/tests/test_get_state_update.rs
+++ b/unit_tests/tests/test_get_state_update.rs
@@ -3,7 +3,7 @@
 mod common;
 use common::*;
 
-use starknet_core::types::{BlockId, BlockTag, StarknetError};
+use starknet_core::types::{BlockId, StarknetError};
 use starknet_providers::{jsonrpc::HttpTransport, JsonRpcClient, Provider};
 use std::collections::HashMap;
 
@@ -47,7 +47,7 @@ async fn work_existing_block(clients: HashMap<String, JsonRpcClient<HttpTranspor
     let deoxys = &clients[DEOXYS];
     let pathfinder = &clients[PATHFINDER];
 
-    let block_number = get_block_setting();
+    let block_number = BlockId::Number(100);
 
     let response_deoxys = deoxys
         .get_state_update(block_number)

--- a/unit_tests/tests/test_get_storage_at.rs
+++ b/unit_tests/tests/test_get_storage_at.rs
@@ -114,16 +114,28 @@ async fn work_get_storage(clients: HashMap<String, JsonRpcClient<HttpTransport>>
     // TODO: get contract key from field name
     let response_deoxys = deoxys
         .get_storage_at(
-            FieldElement::from_hex_be("0x06c780b25d325d49e08175b47d3bc93c53323917d7df3a8084d387d63e84a49b").unwrap(),
-            FieldElement::from_hex_be("0x0000000000000000000000000000000000000000000000000000000000000005").unwrap(),
+            FieldElement::from_hex_be(
+                "0x06c780b25d325d49e08175b47d3bc93c53323917d7df3a8084d387d63e84a49b",
+            )
+            .unwrap(),
+            FieldElement::from_hex_be(
+                "0x0000000000000000000000000000000000000000000000000000000000000005",
+            )
+            .unwrap(),
             BlockId::Number(2000),
         )
         .await
         .expect("Error waiting for response from Deoxys client");
     let response_pathfinder = pathfinder
         .get_storage_at(
-            FieldElement::from_hex_be("0x06c780b25d325d49e08175b47d3bc93c53323917d7df3a8084d387d63e84a49b").unwrap(),
-            FieldElement::from_hex_be("0x0000000000000000000000000000000000000000000000000000000000000005").unwrap(),
+            FieldElement::from_hex_be(
+                "0x06c780b25d325d49e08175b47d3bc93c53323917d7df3a8084d387d63e84a49b",
+            )
+            .unwrap(),
+            FieldElement::from_hex_be(
+                "0x0000000000000000000000000000000000000000000000000000000000000005",
+            )
+            .unwrap(),
             BlockId::Number(2000),
         )
         .await

--- a/unit_tests/tests/test_get_storage_at.rs
+++ b/unit_tests/tests/test_get_storage_at.rs
@@ -91,7 +91,7 @@ async fn fail_invalid_storage_key(clients: HashMap<String, JsonRpcClient<HttpTra
         .get_storage_at(
             FieldElement::from_hex_be(CONTRACT_ADDR).unwrap(),
             FieldElement::ZERO,
-            BlockId::Tag(BlockTag::Latest),
+            BlockId::Number(1000),
         )
         .await
         .expect("Error waiting for response from Deoxys client");
@@ -107,7 +107,6 @@ async fn fail_invalid_storage_key(clients: HashMap<String, JsonRpcClient<HttpTra
 ///
 #[rstest]
 #[tokio::test]
-#[ignore = "slash this ignore when Deoxys node is fully synced"]
 async fn work_get_storage(clients: HashMap<String, JsonRpcClient<HttpTransport>>) {
     let deoxys = &clients[DEOXYS];
     let pathfinder = &clients[PATHFINDER];
@@ -115,17 +114,17 @@ async fn work_get_storage(clients: HashMap<String, JsonRpcClient<HttpTransport>>
     // TODO: get contract key from field name
     let response_deoxys = deoxys
         .get_storage_at(
-            FieldElement::from_hex_be(CONTRACT_ADDR).unwrap(),
-            FieldElement::from_hex_be(CONTRACT_KEY).unwrap(),
-            BlockId::Tag(BlockTag::Latest),
+            FieldElement::from_hex_be("0x06c780b25d325d49e08175b47d3bc93c53323917d7df3a8084d387d63e84a49b").unwrap(),
+            FieldElement::from_hex_be("0x0000000000000000000000000000000000000000000000000000000000000005").unwrap(),
+            BlockId::Number(2000),
         )
         .await
         .expect("Error waiting for response from Deoxys client");
     let response_pathfinder = pathfinder
         .get_storage_at(
-            FieldElement::from_hex_be(CONTRACT_ADDR).unwrap(),
-            FieldElement::from_hex_be(CONTRACT_KEY).unwrap(),
-            BlockId::Tag(BlockTag::Latest),
+            FieldElement::from_hex_be("0x06c780b25d325d49e08175b47d3bc93c53323917d7df3a8084d387d63e84a49b").unwrap(),
+            FieldElement::from_hex_be("0x0000000000000000000000000000000000000000000000000000000000000005").unwrap(),
+            BlockId::Number(2000),
         )
         .await
         .expect("Error waiting for response from Pathfinder client");

--- a/unit_tests/tests/test_get_transaction_status.rs
+++ b/unit_tests/tests/test_get_transaction_status.rs
@@ -51,12 +51,12 @@ async fn work_transaction_accepted_on_l1(clients: HashMap<String, JsonRpcClient<
     let pathfinder = &clients[PATHFINDER];
 
     let response_deoxys = deoxys
-        .get_transaction_status(FieldElement::from_hex_be(TRANSACTION_INVOKE).unwrap())
+        .get_transaction_status(FieldElement::from_hex_be("0x02cdada29d741a0e0308ce56ac23376d7ca735474d53b2d5da0400b8eab0c7aa").unwrap())
         .await
         .expect(ERR_DEOXYS);
 
     let response_pathfinder = pathfinder
-        .get_transaction_status(FieldElement::from_hex_be(TRANSACTION_INVOKE).unwrap())
+        .get_transaction_status(FieldElement::from_hex_be("0x02cdada29d741a0e0308ce56ac23376d7ca735474d53b2d5da0400b8eab0c7aa").unwrap())
         .await
         .expect(ERR_PATHFINDER);
 

--- a/unit_tests/tests/test_get_transaction_status.rs
+++ b/unit_tests/tests/test_get_transaction_status.rs
@@ -51,12 +51,22 @@ async fn work_transaction_accepted_on_l1(clients: HashMap<String, JsonRpcClient<
     let pathfinder = &clients[PATHFINDER];
 
     let response_deoxys = deoxys
-        .get_transaction_status(FieldElement::from_hex_be("0x02cdada29d741a0e0308ce56ac23376d7ca735474d53b2d5da0400b8eab0c7aa").unwrap())
+        .get_transaction_status(
+            FieldElement::from_hex_be(
+                "0x02cdada29d741a0e0308ce56ac23376d7ca735474d53b2d5da0400b8eab0c7aa",
+            )
+            .unwrap(),
+        )
         .await
         .expect(ERR_DEOXYS);
 
     let response_pathfinder = pathfinder
-        .get_transaction_status(FieldElement::from_hex_be("0x02cdada29d741a0e0308ce56ac23376d7ca735474d53b2d5da0400b8eab0c7aa").unwrap())
+        .get_transaction_status(
+            FieldElement::from_hex_be(
+                "0x02cdada29d741a0e0308ce56ac23376d7ca735474d53b2d5da0400b8eab0c7aa",
+            )
+            .unwrap(),
+        )
         .await
         .expect(ERR_PATHFINDER);
 

--- a/unit_tests/tests/test_syncing.rs
+++ b/unit_tests/tests/test_syncing.rs
@@ -27,6 +27,9 @@ async fn syncing(clients: HashMap<String, JsonRpcClient<HttpTransport>>) {
         .await
         .expect("Error while getting sync status from pathfinder node");
 
+    println!("Deoxys: {:?}", response_deoxys);
+    println!("Pathfinder: {:?}", response_pathfinder);
+
     assert!(compare_sync_status(response_deoxys, response_pathfinder));
 }
 

--- a/unit_tests/tests/test_syncing.rs
+++ b/unit_tests/tests/test_syncing.rs
@@ -27,9 +27,6 @@ async fn syncing(clients: HashMap<String, JsonRpcClient<HttpTransport>>) {
         .await
         .expect("Error while getting sync status from pathfinder node");
 
-    println!("Deoxys: {:?}", response_deoxys);
-    println!("Pathfinder: {:?}", response_pathfinder);
-
     assert!(compare_sync_status(response_deoxys, response_pathfinder));
 }
 

--- a/unit_tests/tests/test_trace_transaction.rs
+++ b/unit_tests/tests/test_trace_transaction.rs
@@ -61,7 +61,7 @@ async fn fail_no_trace_available(deoxys: JsonRpcClient<HttpTransport>) {
         let is_correct_error = checking_error_format(
             &error,
             StarknetError::NoTraceAvailable(NoTraceAvailableErrorData {
-                status: SequencerTransactionStatus::Rejected, //Check this because here Pathfinder and Juno return a Trace but with a revert_reason":"Error in the called contract
+                status: SequencerTransactionStatus::Rejected, //Check this because here Pathfinder and Juno return a ContractError but with a revert_reason":"Error in the called contract,
             }),
         );
 

--- a/unit_tests/tests/test_trace_transaction.rs
+++ b/unit_tests/tests/test_trace_transaction.rs
@@ -12,16 +12,15 @@ use starknet_providers::{
     Provider,
 };
 
-
 #[rstest]
 #[tokio::test]
 async fn fail_non_existing_hash(deoxys: JsonRpcClient<HttpTransport>) {
+    let transaction_hash = FieldElement::from_hex_be(
+        "0x02x02d6f0d7sbc71bsc629cde0w8199ccfb6er8343a76943475405817737f76c",
+    )
+    .unwrap(); // non-existent transaction hash
 
-    let transaction_hash = FieldElement::from_hex_be("0x02x02d6f0d7sbc71bsc629cde0w8199ccfb6er8343a76943475405817737f76c").unwrap(); // non-existent transaction hash
-
-    let response_deoxys = deoxys
-        .trace_transaction(transaction_hash)
-        .await;
+    let response_deoxys = deoxys.trace_transaction(transaction_hash).await;
 
     assert!(
         response_deoxys.is_err(),
@@ -29,7 +28,8 @@ async fn fail_non_existing_hash(deoxys: JsonRpcClient<HttpTransport>) {
     );
 
     if let Err(error) = response_deoxys {
-        let is_correct_error = checking_error_format(&error, StarknetError::TransactionHashNotFound);
+        let is_correct_error =
+            checking_error_format(&error, StarknetError::TransactionHashNotFound);
 
         assert!(
             is_correct_error,
@@ -42,12 +42,12 @@ async fn fail_non_existing_hash(deoxys: JsonRpcClient<HttpTransport>) {
 #[rstest]
 #[tokio::test]
 async fn fail_no_trace_available(deoxys: JsonRpcClient<HttpTransport>) {
+    let transaction_hash = FieldElement::from_hex_be(
+        "0x2062dc37facfcc3bed03163dbbde0e3874bf8b231628c6aa21ac2d094b94372",
+    )
+    .unwrap(); // first tx reverted at block 164901
 
-    let transaction_hash = FieldElement::from_hex_be("0x2062dc37facfcc3bed03163dbbde0e3874bf8b231628c6aa21ac2d094b94372").unwrap(); // first tx reverted at block 164901
-
-    let response_deoxys = deoxys
-        .trace_transaction(transaction_hash)
-        .await;
+    let response_deoxys = deoxys.trace_transaction(transaction_hash).await;
 
     assert!(
         response_deoxys.is_err(),
@@ -66,9 +66,14 @@ async fn fail_no_trace_available(deoxys: JsonRpcClient<HttpTransport>) {
 
 #[rstest]
 #[tokio::test]
-async fn work_trace_transaction(deoxys: JsonRpcClient<HttpTransport>, pathfinder: JsonRpcClient<HttpTransport>) {
-
-    let transaction_hash = FieldElement::from_hex_be("0x04456c75586c033f4c8f6731a87d10ff5779e40c351e9c8378590ae2a3f823da").unwrap(); // first tx accepted at block 10000
+async fn work_trace_transaction(
+    deoxys: JsonRpcClient<HttpTransport>,
+    pathfinder: JsonRpcClient<HttpTransport>,
+) {
+    let transaction_hash = FieldElement::from_hex_be(
+        "0x04456c75586c033f4c8f6731a87d10ff5779e40c351e9c8378590ae2a3f823da",
+    )
+    .unwrap(); // first tx accepted at block 10000
 
     let response_deoxys = deoxys
         .trace_transaction(transaction_hash)

--- a/unit_tests/tests/test_trace_transaction.rs
+++ b/unit_tests/tests/test_trace_transaction.rs
@@ -1,0 +1,84 @@
+#![feature(assert_matches)]
+
+mod common;
+use common::*;
+
+use std::assert_matches::assert_matches;
+use std::sync::Arc;
+
+use starknet_core::types::{BlockId, BlockTag, FieldElement, StarknetError};
+use starknet_providers::{
+    jsonrpc::{HttpTransport, JsonRpcClient},
+    Provider,
+};
+
+
+#[rstest]
+#[tokio::test]
+async fn fail_non_existing_hash(deoxys: JsonRpcClient<HttpTransport>) {
+
+    let transaction_hash = FieldElement::from_hex_be("0x02x02d6f0d7sbc71bsc629cde0w8199ccfb6er8343a76943475405817737f76c").unwrap(); // non-existent transaction hash
+
+    let response_deoxys = deoxys
+        .trace_transaction(transaction_hash)
+        .await;
+
+    assert!(
+        response_deoxys.is_err(),
+        "Expected an error, but got a result"
+    );
+
+    if let Err(error) = response_deoxys {
+        let is_correct_error = checking_error_format(&error, StarknetError::TransactionHashNotFound);
+
+        assert!(
+            is_correct_error,
+            "Expected TransactionHashNotFound error, but got a different error"
+        );
+    }
+}
+
+/// Starknet-spec : Extra information on why trace is not available. Either it wasn't executed yet (RECEIVED), or the transaction failed (REJECTED.
+#[rstest]
+#[tokio::test]
+async fn fail_no_trace_available(deoxys: JsonRpcClient<HttpTransport>) {
+
+    let transaction_hash = FieldElement::from_hex_be("0x2062dc37facfcc3bed03163dbbde0e3874bf8b231628c6aa21ac2d094b94372").unwrap(); // first tx reverted at block 164901
+
+    let response_deoxys = deoxys
+        .trace_transaction(transaction_hash)
+        .await;
+
+    assert!(
+        response_deoxys.is_err(),
+        "Expected an error, but got a result"
+    );
+
+    if let Err(error) = response_deoxys {
+        let is_correct_error = checking_error_format(&error, StarknetError::NoTraceAvailable);
+
+        assert!(
+            is_correct_error,
+            "Expected NoTraceAvailable error, but got a different error"
+        );
+    }
+}
+
+#[rstest]
+#[tokio::test]
+async fn work_trace_transaction(deoxys: JsonRpcClient<HttpTransport>, pathfinder: JsonRpcClient<HttpTransport>) {
+
+    let transaction_hash = FieldElement::from_hex_be("0x04456c75586c033f4c8f6731a87d10ff5779e40c351e9c8378590ae2a3f823da").unwrap(); // first tx accepted at block 10000
+
+    let response_deoxys = deoxys
+        .trace_transaction(transaction_hash)
+        .await
+        .expect(ERR_DEOXYS);
+
+    let response_pathfinder = pathfinder
+        .trace_transaction(transaction_hash)
+        .await
+        .expect(ERR_PATHFINDER);
+
+    assert_eq!(response_deoxys, response_pathfinder);
+}


### PR DESCRIPTION
# Pull Request Type

- Feature

# What is the new behavior ?

Provides tests for trace_transaction method in order to ensure failing and working cases as follow : 
- ```fail_non_existing_hash```
- ```fail_no_trace_available```
- ```work_trace_transaction```

# Does this introduce a breaking change ?

No 

# Other information